### PR TITLE
Compute TPO summaries for each calendar day

### DIFF
--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -182,7 +182,7 @@ def _snapshot_payload(candles: Iterable[Mapping[str, float]]) -> Mapping[str, ob
 
 def test_compute_session_profiles_respects_last_n() -> None:
     base = datetime(2024, 5, 1, tzinfo=timezone.utc)
-    candles = make_unimodal(n=800, base=base)
+    candles = make_unimodal(n=60 * 24 * 4, base=base)
     sessions = list(Meta.iter_vwap_sessions())
     summaries = compute_session_profiles(
         candles,
@@ -192,10 +192,30 @@ def test_compute_session_profiles_respects_last_n() -> None:
         adaptive_bins=False,
         value_area_pct=0.7,
     )
-    assert len(summaries) <= 2
-    if summaries:
-        dates = [entry["date"] for entry in summaries]
-        assert dates == sorted(dates)
+    assert summaries, "Expected at least one TPO summary"
+
+    daily_entries = [entry for entry in summaries if entry.get("session") == "daily"]
+    assert daily_entries, "Expected daily TPO entries"
+    assert len(daily_entries) <= 2
+
+    allowed_dates = {entry["date"] for entry in daily_entries}
+    assert allowed_dates
+    assert allowed_dates == {entry["date"] for entry in summaries}
+    expected_dates = {
+        (base.date() + timedelta(days=offset)).isoformat() for offset in range(2, 4)
+    }
+    assert allowed_dates == expected_dates
+
+    ordered_dates = [entry["date"] for entry in summaries]
+    assert ordered_dates == sorted(ordered_dates)
+
+    for day_entry in daily_entries:
+        nested = day_entry.get("sessions", [])
+        assert isinstance(nested, list)
+        for nested_entry in nested:
+            assert nested_entry.get("date") == day_entry["date"]
+    if any(day_entry.get("sessions") for day_entry in daily_entries):
+        assert summaries[-1]["session"] != "daily"
 
 
 def test_profile_endpoint_returns_payload(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- aggregate minute candles by calendar day before building TPO payloads
- include daily summaries with nested session entries while preserving session-level outputs
- update the profile test to validate multi-day coverage and revised last_n semantics

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6df40d47083249afa1e9c905ae091