### PR TITLE
Allow profile endpoint to use full snapshot candle range

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -263,7 +263,12 @@ async def profile_endpoint(
         raw_candles = []
 
     try:
-        normalised = normalise_ohlcv(symbol, timeframe, raw_candles)
+        normalised = normalise_ohlcv(
+            symbol,
+            timeframe,
+            raw_candles,
+            full_snapshot=True,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 


### PR DESCRIPTION
## Summary
- add a `full_snapshot` option to OHLC normalisation so callers can bypass the timeframe window limit
- request the unrestricted candle series when building profile responses so all TPO days are included
- cover the profile endpoint with a regression test that ensures multi-day snapshots return daily entries for each day

## Testing
- PYTHONPATH=. pytest tests/test_profile.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e8c49c288324866cb06eb1a5113d