### PR TITLE
Add liquidity detection module

### DIFF
--- a/src/meta.py
+++ b/src/meta.py
@@ -2,7 +2,15 @@
 from __future__ import annotations
 
 from datetime import time
-from typing import Iterable, Tuple
+from typing import Dict, Iterable, Tuple
+
+
+# Hardcoded tick sizes for popular perpetual pairs used as liquidity fallbacks.
+HARDCODED_TICK_SIZES: Dict[str, float] = {
+    "BTCUSDT": 0.1,
+    "ETHUSDT": 0.01,
+    "SOLUSDT": 0.001,
+}
 
 
 class Meta:

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -28,6 +28,7 @@ from .presets import (
     save_preset,
     update_preset,
 )
+from .liquidity import build_liquidity_snapshot
 from .ohlc import (
     TIMEFRAME_WINDOWS,
     fetch_ohlcv,
@@ -40,6 +41,7 @@ from .trades import AggTradeCollector
 
 __all__ = [
     "build_inspection_payload",
+    "build_liquidity_snapshot",
     "build_check_all_datas",
     "build_placeholder_snapshot",
     "DEFAULT_SYMBOL",

--- a/src/services/check_all_datas.py
+++ b/src/services/check_all_datas.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Sequence
 
 import httpx
 
-from .inspection import build_htf_section
+from .inspection import build_htf_section, resolve_liquidity_tick_size
 from .liquidity import build_liquidity_snapshot
 from .presets import resolve_profile_config
 from .profile import build_profile_package
@@ -1300,7 +1300,7 @@ def build_check_all_datas(
 
     tick_size_value = profile_config.get("tick_size") if isinstance(profile_config, Mapping) else None
     tick_size_numeric: float | None = None
-    if isinstance(tick_size_value, (int, float)):
+    if isinstance(tick_size_value, (int, float)) and tick_size_value > 0:
         tick_size_numeric = float(tick_size_value)
 
     liquidity_frames: Dict[str, Dict[str, Any]] = {}
@@ -1339,6 +1339,28 @@ def build_check_all_datas(
         daily_series = _clean_series(frames.get("1d"))
         if daily_series:
             liquidity_frames["1d"] = {"candles": daily_series, "source": "short_window"}
+
+    tick_inference_frames: Dict[str, Sequence[Mapping[str, Any]]] = {}
+    for tf_key, payload in liquidity_frames.items():
+        candles = payload.get("candles") if isinstance(payload, Mapping) else None
+        if isinstance(candles, Sequence):
+            tick_inference_frames[tf_key] = [c for c in candles if isinstance(c, Mapping)]  # type: ignore[list-item]
+
+    tick_size_numeric, tick_size_source = resolve_liquidity_tick_size(
+        symbol,
+        tick_size_value,
+        tick_inference_frames,
+        logger=logging.getLogger(__name__),
+    )
+
+    logging.getLogger(__name__).debug(
+        "Liquidity tick size resolved for check-all",  # contextual debug entry
+        extra={
+            "symbol": symbol,
+            "tick_size": tick_size_numeric,
+            "tick_size_source": tick_size_source,
+        },
+    )
 
     liquidity_payload = build_liquidity_snapshot(
         liquidity_frames,

--- a/src/services/inspection.py
+++ b/src/services/inspection.py
@@ -1166,8 +1166,11 @@ def build_inspection_payload(snapshot: Snapshot) -> Dict[str, Any]:
     raw_meta = snapshot.get("meta") if isinstance(snapshot.get("meta"), Mapping) else {}
     liquidity_config = raw_meta.get("liquidity") if isinstance(raw_meta, Mapping) else None
     tick_size = float(tick_size_value) if isinstance(tick_size_value, (int, float)) and tick_size_value > 0 else None
+    liquidity_frames = {
+        tf: {"candles": list(candles)} for tf, candles in full_candles_by_tf.items()
+    }
     liquidity_payload = build_liquidity_snapshot(
-        normalised_frames,
+        liquidity_frames,
         tick_size=tick_size,
         selection=selection,
         config=liquidity_config if isinstance(liquidity_config, Mapping) else None,

--- a/src/services/inspection.py
+++ b/src/services/inspection.py
@@ -1365,6 +1365,22 @@ def build_inspection_payload(snapshot: Snapshot) -> Dict[str, Any]:
         config=liquidity_config if isinstance(liquidity_config, Mapping) else None,
     )
 
+    liquidity_diagnostics: Dict[str, Any] = {}
+    if isinstance(liquidity_payload, Mapping):
+        diagnostics_payload = liquidity_payload.get("diagnostics")
+        if isinstance(diagnostics_payload, Mapping):
+            liquidity_diagnostics = diagnostics_payload
+        liquidity_payload = dict(liquidity_payload)
+        liquidity_payload.pop("diagnostics", None)
+    else:
+        liquidity_payload = {
+            "eqh": [],
+            "eql": [],
+            "pdh": None,
+            "pdl": None,
+            "sweeps": [],
+        }
+
     logging.getLogger(__name__).debug(
         "Liquidity tick size applied",
         extra={
@@ -1415,6 +1431,7 @@ def build_inspection_payload(snapshot: Snapshot) -> Dict[str, Any]:
         "snapshot_id": snapshot.get("id"),
         "captured_at": snapshot.get("captured_at"),
         "frames": diagnostics_frames,
+        "liquidity": liquidity_diagnostics,
     }
 
     return {"DATA": data_section, "DIAGNOSTICS": diagnostics_section}

--- a/src/services/inspection.py
+++ b/src/services/inspection.py
@@ -9,6 +9,7 @@ import os
 import re
 from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta, timezone, time as dtime
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import (
     Any,
@@ -30,7 +31,7 @@ from .ohlc import TIMEFRAME_WINDOWS, TIMEFRAME_TO_MS, normalise_ohlcv, resample_
 from .profile import build_profile_package
 from .presets import resolve_profile_config
 from .zones import Config as ZonesConfig, detect_zones
-from ..meta import Meta
+from ..meta import HARDCODED_TICK_SIZES, Meta
 
 Snapshot = Dict[str, Any]
 
@@ -49,6 +50,9 @@ MS_IN_DAY = 86_400_000
 HTF_TIMEFRAMES: Tuple[str, ...] = ("15m", "1h", "4h", "1d")
 MINUTE_INTERVAL_MS = TIMEFRAME_TO_MS.get("1m", 60_000)
 BINANCE_FAPI_REST = "https://fapi.binance.com/fapi/v1/klines"
+
+_PRICE_FIELDS: Tuple[str, ...] = ("o", "h", "l", "c")
+_MAX_TICK_SAMPLES = 5000
 
 
 def _safe_int(value: object | None) -> int | None:
@@ -195,6 +199,132 @@ def ensure_higher_timeframes(
             },
         )
     return generated
+
+
+def _infer_tick_size_from_frames(
+    frames: Mapping[str, Sequence[Mapping[str, Any]]]
+) -> float | None:
+    """Infer a plausible tick size from OHLCV data when metadata is missing."""
+
+    samples: List[Decimal] = []
+    seen: set[Decimal] = set()
+    for tf_key, candles in frames.items():
+        if not isinstance(candles, Sequence):
+            continue
+        for candle in candles:
+            if not isinstance(candle, Mapping):
+                continue
+            for field in _PRICE_FIELDS:
+                price = _coerce_float(candle.get(field))
+                if price is None:
+                    continue
+                try:
+                    decimal_value = Decimal(str(price))
+                except (InvalidOperation, ValueError):
+                    continue
+                if decimal_value in seen:
+                    continue
+                seen.add(decimal_value)
+                samples.append(decimal_value)
+            if len(samples) >= _MAX_TICK_SAMPLES:
+                break
+        if len(samples) >= _MAX_TICK_SAMPLES:
+            break
+
+    if len(samples) < 2:
+        return None
+
+    samples.sort()
+    min_step: Decimal | None = None
+    previous = samples[0]
+    for current in samples[1:]:
+        diff = current - previous
+        if diff > 0:
+            if min_step is None or diff < min_step:
+                min_step = diff
+                if min_step == 0:
+                    min_step = None
+        previous = current
+
+    if min_step is not None and min_step > 0:
+        return float(min_step)
+
+    max_precision = 0
+    for value in samples:
+        exponent = -value.as_tuple().exponent
+        if exponent > max_precision:
+            max_precision = exponent
+
+    if max_precision > 0:
+        return float(10 ** (-max_precision))
+    return None
+
+
+def resolve_liquidity_tick_size(
+    symbol: str,
+    profile_tick_size: Any,
+    frames: Mapping[str, Sequence[Mapping[str, Any]]],
+    *,
+    logger: logging.Logger | None = None,
+) -> Tuple[float, str]:
+    """Resolve a positive tick size for liquidity detection with fallbacks."""
+
+    log = logger or logging.getLogger(__name__)
+    symbol_key = (symbol or "UNKNOWN").upper()
+
+    profile_numeric: float | None = None
+    if isinstance(profile_tick_size, (int, float)):
+        profile_numeric = float(profile_tick_size)
+    elif isinstance(profile_tick_size, str):
+        try:
+            profile_numeric = float(profile_tick_size)
+        except (TypeError, ValueError):
+            profile_numeric = None
+
+    if profile_numeric is not None and profile_numeric > 0:
+        tick_size = profile_numeric
+        tick_source = "tick_size_from_profile"
+        log.debug(
+            "Resolved liquidity tick size from profile",
+            extra={"symbol": symbol_key, "tick_size": tick_size, "tick_size_source": tick_source},
+        )
+        return tick_size, tick_source
+
+    hardcoded = HARDCODED_TICK_SIZES.get(symbol_key)
+    if isinstance(hardcoded, (int, float)) and hardcoded > 0:
+        tick_size = float(hardcoded)
+        tick_source = "tick_size_from_hardcoded"
+        log.debug(
+            "Using hardcoded liquidity tick size fallback",
+            extra={"symbol": symbol_key, "tick_size": tick_size, "tick_size_source": tick_source},
+        )
+        return tick_size, tick_source
+
+    tick_source = "tick_size_from_auto"
+    log.warning(
+        "Profile tick size missing; attempting auto inference",
+        extra={"symbol": symbol_key, "tick_size_source": tick_source},
+    )
+
+    inferred = _infer_tick_size_from_frames(frames)
+    if inferred is not None and inferred > 0:
+        tick_size = float(inferred)
+        log.debug(
+            "Auto-inferred liquidity tick size",
+            extra={"symbol": symbol_key, "tick_size": tick_size, "tick_size_source": tick_source},
+        )
+        return tick_size, tick_source
+
+    tick_size = 1.0
+    log.warning(
+        "Auto tick size inference failed; defaulting to 1.0",
+        extra={"symbol": symbol_key, "tick_size_source": tick_source},
+    )
+    log.debug(
+        "Using default liquidity tick size after inference failure",
+        extra={"symbol": symbol_key, "tick_size": tick_size, "tick_size_source": tick_source},
+    )
+    return tick_size, tick_source
 
 
 def _expected_minute_sequence(start_ms: int, end_ms: int) -> List[int]:
@@ -1215,7 +1345,12 @@ def build_inspection_payload(snapshot: Snapshot) -> Dict[str, Any]:
 
     raw_meta = snapshot.get("meta") if isinstance(snapshot.get("meta"), Mapping) else {}
     liquidity_config = raw_meta.get("liquidity") if isinstance(raw_meta, Mapping) else None
-    tick_size = float(tick_size_value) if isinstance(tick_size_value, (int, float)) and tick_size_value > 0 else None
+    tick_size, tick_size_source = resolve_liquidity_tick_size(
+        symbol,
+        tick_size_value,
+        full_candles_by_tf,
+        logger=logging.getLogger(__name__),
+    )
     liquidity_frames: Dict[str, Dict[str, Any]] = {}
     for tf, candles in full_candles_by_tf.items():
         payload: Dict[str, Any] = {"candles": list(candles)}
@@ -1228,6 +1363,15 @@ def build_inspection_payload(snapshot: Snapshot) -> Dict[str, Any]:
         tick_size=tick_size,
         selection=selection,
         config=liquidity_config if isinstance(liquidity_config, Mapping) else None,
+    )
+
+    logging.getLogger(__name__).debug(
+        "Liquidity tick size applied",
+        extra={
+            "symbol": symbol,
+            "tick_size": tick_size,
+            "tick_size_source": tick_size_source,
+        },
     )
 
     data_section = {

--- a/src/services/liquidity.py
+++ b/src/services/liquidity.py
@@ -1,0 +1,471 @@
+"""Liquidity level and sweep detection helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import math
+import statistics
+from typing import Any, Dict, List, Mapping, MutableMapping, Sequence
+
+MS_IN_DAY = 86_400_000
+SUPPORTED_TIMEFRAMES: tuple[str, ...] = ("15m", "1h")
+
+
+@dataclass(slots=True)
+class LiquidityConfig:
+    """Runtime configuration for liquidity detection."""
+
+    swing_window: int = 2
+    lookback_swings: int = 30
+    r_ticks: int = 2
+    atr_period: int = 14
+    sweep_atr_multiplier: float = 0.5
+
+
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if math.isfinite(numeric):
+            return numeric
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isfinite(numeric):
+        return numeric
+    return None
+
+
+def _quantise(price: float, tick_size: float | None) -> float:
+    if tick_size is None or tick_size <= 0:
+        return float(price)
+    ticks = round(price / tick_size)
+    return ticks * tick_size
+
+
+def _resolve_config(raw: Mapping[str, Any] | None) -> LiquidityConfig:
+    if not isinstance(raw, Mapping):
+        return LiquidityConfig()
+
+    config = LiquidityConfig()
+
+    def _positive_int(value: Any, default: int, *, lower: int = 1, upper: int | None = None) -> int:
+        try:
+            numeric = int(value)
+        except (TypeError, ValueError):
+            return default
+        if numeric < lower:
+            return default
+        if upper is not None and numeric > upper:
+            return upper
+        return numeric
+
+    config.swing_window = _positive_int(raw.get("swing_window"), config.swing_window, lower=1, upper=10)
+    config.lookback_swings = _positive_int(raw.get("lookback"), config.lookback_swings, lower=5, upper=200)
+    config.r_ticks = _positive_int(raw.get("r_ticks"), config.r_ticks, lower=1, upper=20)
+    config.atr_period = _positive_int(raw.get("atr_period"), config.atr_period, lower=1, upper=200)
+
+    multiplier = raw.get("sweep_atr_multiplier")
+    try:
+        numeric = float(multiplier)
+    except (TypeError, ValueError):
+        numeric = config.sweep_atr_multiplier
+    if math.isfinite(numeric) and numeric >= 0:
+        config.sweep_atr_multiplier = numeric
+
+    return config
+
+
+def _extract_candles(frame: Mapping[str, Any] | None) -> List[Mapping[str, Any]]:
+    if not isinstance(frame, Mapping):
+        return []
+    candles = frame.get("candles")
+    if isinstance(candles, Sequence):
+        return [c for c in candles if isinstance(c, Mapping)]  # type: ignore[list-item]
+    return []
+
+
+def _detect_swings(
+    candles: Sequence[Mapping[str, Any]],
+    *,
+    window: int,
+    kind: str,
+) -> List[MutableMapping[str, Any]]:
+    swings: List[MutableMapping[str, Any]] = []
+    if window <= 0:
+        return swings
+    size = len(candles)
+    for index in range(window, size - window):
+        candle = candles[index]
+        ts = candle.get("t")
+        if not isinstance(ts, (int, float)):
+            continue
+        if kind == "high":
+            price = _coerce_float(candle.get("h"))
+            if price is None:
+                continue
+            higher = True
+            for offset in range(1, window + 1):
+                left = _coerce_float(candles[index - offset].get("h"))
+                right = _coerce_float(candles[index + offset].get("h"))
+                if left is None or right is None or price <= left or price <= right:
+                    higher = False
+                    break
+            if higher:
+                swings.append({"t": int(ts), "price": price})
+        else:
+            price = _coerce_float(candle.get("l"))
+            if price is None:
+                continue
+            lower = True
+            for offset in range(1, window + 1):
+                left = _coerce_float(candles[index - offset].get("l"))
+                right = _coerce_float(candles[index + offset].get("l"))
+                if left is None or right is None or price >= left or price >= right:
+                    lower = False
+                    break
+            if lower:
+                swings.append({"t": int(ts), "price": price})
+    return swings
+
+
+def _cluster_swings(
+    swings: Sequence[Mapping[str, Any]],
+    *,
+    tolerance: float,
+    tick_size: float | None,
+    level_type: str,
+    timeframe: str,
+) -> List[Dict[str, Any]]:
+    if not swings:
+        return []
+
+    ordered = sorted(swings, key=lambda item: item.get("t", 0))
+    clusters: List[Dict[str, Any]] = []
+    for swing in ordered:
+        price_value = _coerce_float(swing.get("price"))
+        time_value = swing.get("t")
+        if price_value is None or not isinstance(time_value, (int, float)):
+            continue
+        quantised_price = _quantise(price_value, tick_size)
+        matched = False
+        for cluster in clusters:
+            if abs(cluster["anchor"] - quantised_price) <= tolerance:
+                cluster["prices"].append(quantised_price)
+                cluster["swings"].append(int(time_value))
+                cluster["anchor"] = statistics.fmean(cluster["prices"])
+                matched = True
+                break
+        if not matched:
+            clusters.append(
+                {
+                    "anchor": quantised_price,
+                    "prices": [quantised_price],
+                    "swings": [int(time_value)],
+                }
+            )
+
+    payload: List[Dict[str, Any]] = []
+    for cluster in clusters:
+        swings_ts = sorted(set(cluster["swings"]))
+        if len(swings_ts) < 2:
+            continue
+        prices = cluster["prices"]
+        if not prices:
+            continue
+        payload.append(
+            {
+                "type": level_type,
+                "tf": timeframe,
+                "price": statistics.fmean(prices),
+                "swings": swings_ts,
+            }
+        )
+    return payload
+
+
+def _compute_atr_series(
+    candles: Sequence[Mapping[str, Any]],
+    *,
+    period: int,
+) -> List[float]:
+    atr_values: List[float] = []
+    if period <= 0:
+        return [0.0 for _ in candles]
+    tr_window: List[float] = []
+    prev_close: float | None = None
+    for candle in candles:
+        high = _coerce_float(candle.get("h"))
+        low = _coerce_float(candle.get("l"))
+        close = _coerce_float(candle.get("c"))
+        if high is None or low is None or close is None:
+            atr_values.append(0.0)
+            prev_close = close
+            continue
+        tr_candidates = [high - low]
+        if prev_close is not None:
+            tr_candidates.extend((abs(high - prev_close), abs(low - prev_close)))
+        true_range = max(tr_candidates) if tr_candidates else 0.0
+        tr_window.append(true_range)
+        if len(tr_window) > period:
+            tr_window.pop(0)
+        atr = sum(tr_window) / len(tr_window) if tr_window else 0.0
+        atr_values.append(atr)
+        prev_close = close
+    return atr_values
+
+
+def _prepare_levels(
+    frames: Mapping[str, Mapping[str, Any]],
+    *,
+    tick_size: float | None,
+    config: LiquidityConfig,
+) -> Dict[str, List[Dict[str, Any]]]:
+    eqh_levels: List[Dict[str, Any]] = []
+    eql_levels: List[Dict[str, Any]] = []
+
+    tolerance = (config.r_ticks * tick_size) if tick_size and tick_size > 0 else 0.0
+
+    for timeframe in SUPPORTED_TIMEFRAMES:
+        candles = _extract_candles(frames.get(timeframe))
+        if len(candles) < 2 * config.swing_window + 1:
+            continue
+        swings_high = _detect_swings(candles, window=config.swing_window, kind="high")
+        swings_low = _detect_swings(candles, window=config.swing_window, kind="low")
+        if config.lookback_swings > 0:
+            swings_high = swings_high[-config.lookback_swings :]
+            swings_low = swings_low[-config.lookback_swings :]
+        eqh_levels.extend(
+            _cluster_swings(
+                swings_high,
+                tolerance=tolerance,
+                tick_size=tick_size,
+                level_type="eqh",
+                timeframe=timeframe,
+            )
+        )
+        eql_levels.extend(
+            _cluster_swings(
+                swings_low,
+                tolerance=tolerance,
+                tick_size=tick_size,
+                level_type="eql",
+                timeframe=timeframe,
+            )
+        )
+
+    for level in eqh_levels:
+        level["tolerance"] = tolerance
+    for level in eql_levels:
+        level["tolerance"] = tolerance
+
+    return {"eqh": eqh_levels, "eql": eql_levels}
+
+
+def _resolve_previous_day(
+    candles: Sequence[Mapping[str, Any]],
+    *,
+    reference_end_ms: int | None,
+) -> Dict[str, Dict[str, Any] | None]:
+    if not candles:
+        return {"pdh": None, "pdl": None}
+
+    if reference_end_ms is None:
+        last_ts = candles[-1].get("t")
+        reference_end_ms = int(last_ts) + MS_IN_DAY if isinstance(last_ts, (int, float)) else None
+
+    if reference_end_ms is None:
+        return {"pdh": None, "pdl": None}
+
+    reference_day = datetime.fromtimestamp(reference_end_ms / 1000, tz=timezone.utc).date()
+    previous_day = reference_day - timedelta(days=1)
+
+    target_high: Dict[str, Any] | None = None
+    target_low: Dict[str, Any] | None = None
+    for candle in reversed(candles):
+        open_ts = candle.get("t")
+        if not isinstance(open_ts, (int, float)):
+            continue
+        candle_day = datetime.fromtimestamp(open_ts / 1000, tz=timezone.utc).date()
+        if candle_day != previous_day:
+            continue
+        high = _coerce_float(candle.get("h"))
+        low = _coerce_float(candle.get("l"))
+        if high is None or low is None:
+            continue
+        day_start = datetime.combine(previous_day, datetime.min.time(), tzinfo=timezone.utc)
+        target_high = {"t": int(day_start.timestamp() * 1000), "price": high}
+        target_low = {"t": int(day_start.timestamp() * 1000), "price": low}
+        break
+
+    return {"pdh": target_high, "pdl": target_low}
+
+
+def _detect_sweeps(
+    frames: Mapping[str, Mapping[str, Any]],
+    *,
+    tick_size: float | None,
+    config: LiquidityConfig,
+    eqh: Sequence[Mapping[str, Any]],
+    eql: Sequence[Mapping[str, Any]],
+    pdh: Mapping[str, Any] | None,
+    pdl: Mapping[str, Any] | None,
+) -> List[Dict[str, Any]]:
+    sweeps: List[Dict[str, Any]] = []
+    tick_min = tick_size if tick_size and tick_size > 0 else 0.0
+
+    upper_levels_by_tf: Dict[str, List[Mapping[str, Any]]] = {tf: [] for tf in SUPPORTED_TIMEFRAMES}
+    lower_levels_by_tf: Dict[str, List[Mapping[str, Any]]] = {tf: [] for tf in SUPPORTED_TIMEFRAMES}
+
+    for level in eqh:
+        tf = str(level.get("tf"))
+        if tf in upper_levels_by_tf:
+            upper_levels_by_tf[tf].append(level)
+    for level in eql:
+        tf = str(level.get("tf"))
+        if tf in lower_levels_by_tf:
+            lower_levels_by_tf[tf].append(level)
+
+    for tf in SUPPORTED_TIMEFRAMES:
+        if pdh:
+            upper_levels_by_tf[tf].append({"type": "pdh", "price": pdh["price"], "t": pdh["t"]})  # type: ignore[index]
+        if pdl:
+            lower_levels_by_tf[tf].append({"type": "pdl", "price": pdl["price"], "t": pdl["t"]})  # type: ignore[index]
+
+    for timeframe, levels in upper_levels_by_tf.items():
+        candles = _extract_candles(frames.get(timeframe))
+        if not candles:
+            continue
+        atr_values = _compute_atr_series(candles, period=config.atr_period)
+        for index, candle in enumerate(candles):
+            high = _coerce_float(candle.get("h"))
+            close = _coerce_float(candle.get("c"))
+            ts = candle.get("t")
+            if high is None or close is None or not isinstance(ts, (int, float)):
+                continue
+            atr_component = atr_values[index] * config.sweep_atr_multiplier
+            for level in levels:
+                level_price = _coerce_float(level.get("price"))
+                if level_price is None:
+                    continue
+                formed_after: int | None = None
+                level_type = str(level.get("type"))
+                if level_type == "eqh":
+                    swings = level.get("swings") if isinstance(level.get("swings"), Sequence) else []
+                    swing_ts = [int(value) for value in swings if isinstance(value, (int, float))]
+                    if swing_ts:
+                        formed_after = max(swing_ts)
+                elif level_type == "pdh" and isinstance(level.get("t"), (int, float)):
+                    formed_after = int(level["t"]) + MS_IN_DAY
+                if formed_after is not None and ts <= formed_after:
+                    continue
+                overshoot = high - level_price
+                if overshoot <= 0:
+                    continue
+                if tick_min > 0 and overshoot < tick_min:
+                    continue
+                if atr_component > 0 and overshoot > atr_component:
+                    continue
+                if close >= level_price:
+                    continue
+                sweeps.append(
+                    {
+                        "type": "sweep_top",
+                        "level_type": level_type,
+                        "level_price": level_price,
+                        "t": int(ts),
+                        "atr_tolerance": atr_component,
+                    }
+                )
+
+    for timeframe, levels in lower_levels_by_tf.items():
+        candles = _extract_candles(frames.get(timeframe))
+        if not candles:
+            continue
+        atr_values = _compute_atr_series(candles, period=config.atr_period)
+        for index, candle in enumerate(candles):
+            low = _coerce_float(candle.get("l"))
+            close = _coerce_float(candle.get("c"))
+            ts = candle.get("t")
+            if low is None or close is None or not isinstance(ts, (int, float)):
+                continue
+            atr_component = atr_values[index] * config.sweep_atr_multiplier
+            for level in levels:
+                level_price = _coerce_float(level.get("price"))
+                if level_price is None:
+                    continue
+                formed_after: int | None = None
+                level_type = str(level.get("type"))
+                if level_type == "eql":
+                    swings = level.get("swings") if isinstance(level.get("swings"), Sequence) else []
+                    swing_ts = [int(value) for value in swings if isinstance(value, (int, float))]
+                    if swing_ts:
+                        formed_after = max(swing_ts)
+                elif level_type == "pdl" and isinstance(level.get("t"), (int, float)):
+                    formed_after = int(level["t"]) + MS_IN_DAY
+                if formed_after is not None and ts <= formed_after:
+                    continue
+                overshoot = level_price - low
+                if overshoot <= 0:
+                    continue
+                if tick_min > 0 and overshoot < tick_min:
+                    continue
+                if atr_component > 0 and overshoot > atr_component:
+                    continue
+                if close <= level_price:
+                    continue
+                sweeps.append(
+                    {
+                        "type": "sweep_bottom",
+                        "level_type": level_type,
+                        "level_price": level_price,
+                        "t": int(ts),
+                        "atr_tolerance": atr_component,
+                    }
+                )
+
+    sweeps.sort(key=lambda item: item.get("t", 0))
+    return sweeps
+
+
+def build_liquidity_snapshot(
+    frames: Mapping[str, Mapping[str, Any]],
+    *,
+    tick_size: float | None,
+    selection: Mapping[str, Any] | None = None,
+    config: Mapping[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Compute liquidity levels and sweeps for the inspection payload."""
+
+    resolved_config = _resolve_config(config)
+
+    levels = _prepare_levels(frames, tick_size=tick_size, config=resolved_config)
+
+    daily_candles = _extract_candles(frames.get("1d"))
+    selection_end = None
+    if isinstance(selection, Mapping):
+        end_value = selection.get("end")
+        if isinstance(end_value, (int, float)):
+            selection_end = int(end_value)
+    daily_levels = _resolve_previous_day(daily_candles, reference_end_ms=selection_end)
+
+    sweeps = _detect_sweeps(
+        frames,
+        tick_size=tick_size,
+        config=resolved_config,
+        eqh=levels["eqh"],
+        eql=levels["eql"],
+        pdh=daily_levels["pdh"],
+        pdl=daily_levels["pdl"],
+    )
+
+    return {
+        "eqh": levels["eqh"],
+        "eql": levels["eql"],
+        "pdh": daily_levels["pdh"],
+        "pdl": daily_levels["pdl"],
+        "sweeps": sweeps,
+    }
+

--- a/src/services/liquidity.py
+++ b/src/services/liquidity.py
@@ -51,6 +51,23 @@ def _quantise(price: float, tick_size: float | None) -> float:
     return ticks * tick_size
 
 
+def _append_reason(
+    sink: List[Dict[str, Any]] | None,
+    reason: str,
+    **context: Any,
+) -> None:
+    """Record a structured diagnostic reason if a sink is provided."""
+
+    if sink is None:
+        return
+    entry: Dict[str, Any] = {"reason": reason}
+    for key, value in context.items():
+        if value is None:
+            continue
+        entry[key] = value
+    sink.append(entry)
+
+
 def _resolve_config(raw: Mapping[str, Any] | None) -> LiquidityConfig:
     if not isinstance(raw, Mapping):
         return LiquidityConfig()
@@ -212,6 +229,7 @@ def _cluster_swings(
     tick_size: float | None,
     level_type: str,
     timeframe: str,
+    reason_sink: List[Dict[str, Any]] | None = None,
 ) -> List[Dict[str, Any]]:
     if not swings:
         LOGGER.debug(
@@ -222,6 +240,7 @@ def _cluster_swings(
                 "reason": "no_swings",
             },
         )
+        _append_reason(reason_sink, "no_swings")
         return []
 
     ordered = sorted(swings, key=lambda item: item.get("t", 0))
@@ -264,6 +283,13 @@ def _cluster_swings(
                     "tick_size": tick_size,
                 },
             )
+            _append_reason(
+                reason_sink,
+                "min_points_fail",
+                swings=swings_ts,
+                tolerance=tolerance,
+                tick_size=tick_size,
+            )
             continue
         prices = cluster["prices"]
         if not prices:
@@ -278,6 +304,14 @@ def _cluster_swings(
                 "swings": swings_ts,
                 "tolerance": tolerance,
             }
+        )
+    if not payload:
+        _append_reason(
+            reason_sink,
+            "no_clusters",
+            swings=len(swings),
+            tolerance=tolerance,
+            tick_size=tick_size,
         )
     return payload
 
@@ -318,11 +352,13 @@ def _prepare_levels(
     *,
     tick_size: float | None,
     config: LiquidityConfig,
-) -> Dict[str, List[Dict[str, Any]]]:
+) -> tuple[Dict[str, List[Mapping[str, Any]]], Dict[str, Any]]:
     eqh_levels: List[Dict[str, Any]] = []
     eql_levels: List[Dict[str, Any]] = []
 
     tolerance = (config.r_ticks * tick_size) if tick_size and tick_size > 0 else 0.0
+
+    diagnostics: Dict[str, Any] = {}
 
     LOGGER.debug(
         "Liquidity swing detection config",
@@ -335,11 +371,30 @@ def _prepare_levels(
         },
     )
 
+    minimum_required = 2 * config.swing_window + 1
+
     for timeframe in SUPPORTED_TIMEFRAMES:
         frame_payload = frames.get(timeframe)
         source_label = _frame_source(frame_payload) or "unknown"
         candles = _extract_candles(frame_payload)
         candle_count = len(candles)
+
+        frame_diag = {
+            "used_source": source_label,
+            "n_bars_total": candle_count,
+            "tick_size": tick_size,
+            "r_ticks": config.r_ticks,
+            "tolerance": tolerance,
+            "swing_window": config.swing_window,
+            "lookback": config.lookback_swings,
+            "atr_period": config.atr_period,
+            "atr_mult": config.sweep_atr_multiplier,
+            "reasons": [],
+            "eqh": {"swing_count": 0, "cluster_count": 0, "reasons": []},
+            "eql": {"swing_count": 0, "cluster_count": 0, "reasons": []},
+        }
+        diagnostics[timeframe] = frame_diag
+
         LOGGER.debug(
             "Evaluating liquidity swings",
             extra={
@@ -348,7 +403,7 @@ def _prepare_levels(
                 "used_source": source_label,
             },
         )
-        if candle_count < 2 * config.swing_window + 1:
+        if candle_count < minimum_required:
             LOGGER.debug(
                 "Skipping liquidity timeframe",
                 extra={
@@ -358,12 +413,20 @@ def _prepare_levels(
                     "used_source": source_label,
                 },
             )
+            _append_reason(
+                frame_diag["reasons"],
+                "too_few_bars",
+                candles=candle_count,
+                required=minimum_required,
+            )
             continue
         swings_high = _detect_swings(candles, window=config.swing_window, kind="high")
         swings_low = _detect_swings(candles, window=config.swing_window, kind="low")
         if config.lookback_swings > 0:
             swings_high = swings_high[-config.lookback_swings :]
             swings_low = swings_low[-config.lookback_swings :]
+        frame_diag["eqh"]["swing_count"] = len(swings_high)
+        frame_diag["eql"]["swing_count"] = len(swings_low)
         LOGGER.debug(
             "Liquidity swings detected",
             extra={
@@ -379,7 +442,9 @@ def _prepare_levels(
             tick_size=tick_size,
             level_type="eqh",
             timeframe=timeframe,
+            reason_sink=frame_diag["eqh"]["reasons"],
         )
+        frame_diag["eqh"]["cluster_count"] = len(eqh_cluster)
         if not eqh_cluster:
             LOGGER.debug(
                 "No EQH clusters on timeframe",
@@ -393,7 +458,9 @@ def _prepare_levels(
             tick_size=tick_size,
             level_type="eql",
             timeframe=timeframe,
+            reason_sink=frame_diag["eql"]["reasons"],
         )
+        frame_diag["eql"]["cluster_count"] = len(eql_cluster)
         if not eql_cluster:
             LOGGER.debug(
                 "No EQL clusters on timeframe",
@@ -424,20 +491,25 @@ def _prepare_levels(
     if not eql_levels:
         LOGGER.debug("No EQL clusters formed", extra={"reason": "no_clusters"})
 
-    return {"eqh": eqh_levels, "eql": eql_levels}
+    return {"eqh": eqh_levels, "eql": eql_levels}, diagnostics
 
 
 def _resolve_previous_day(
     candles: Sequence[Mapping[str, Any]],
     *,
     reference_end_ms: int | None,
-) -> Dict[str, Dict[str, Any] | None]:
+) -> tuple[Dict[str, Dict[str, Any] | None], Dict[str, Any]]:
+    diagnostics: Dict[str, Any] = {
+        "candles": len(candles),
+        "reasons": [],
+    }
     if not candles:
         LOGGER.debug(
             "Unable to resolve previous day levels",
             extra={"reason": "no_daily_candles"},
         )
-        return {"pdh": None, "pdl": None}
+        _append_reason(diagnostics["reasons"], "no_daily_candles")
+        return {"pdh": None, "pdl": None}, diagnostics
 
     if reference_end_ms is None:
         last_ts = candles[-1].get("t")
@@ -448,7 +520,8 @@ def _resolve_previous_day(
             "Unable to resolve previous day levels",
             extra={"reason": "no_reference_time"},
         )
-        return {"pdh": None, "pdl": None}
+        _append_reason(diagnostics["reasons"], "no_reference_time")
+        return {"pdh": None, "pdl": None}, diagnostics
 
     reference_day = datetime.fromtimestamp(reference_end_ms / 1000, tz=timezone.utc).date()
     previous_day = reference_day - timedelta(days=1)
@@ -476,8 +549,16 @@ def _resolve_previous_day(
             "Previous day levels unavailable",
             extra={"reason": "no_daily_candle_prev_utc", "day": str(previous_day)},
         )
+        _append_reason(
+            diagnostics["reasons"],
+            "no_daily_candle_prev_utc",
+            day=str(previous_day),
+        )
 
-    return {"pdh": target_high, "pdl": target_low}
+    diagnostics["found"] = bool(target_high and target_low)
+    diagnostics["day"] = str(previous_day)
+
+    return {"pdh": target_high, "pdl": target_low}, diagnostics
 
 
 def _detect_sweeps(
@@ -489,7 +570,7 @@ def _detect_sweeps(
     eql: Sequence[Mapping[str, Any]],
     pdh: Mapping[str, Any] | None,
     pdl: Mapping[str, Any] | None,
-) -> List[Dict[str, Any]]:
+) -> tuple[List[Dict[str, Any]], Dict[str, Any]]:
     sweeps: List[Dict[str, Any]] = []
     tick_min = tick_size if tick_size and tick_size > 0 else 0.0
 
@@ -520,23 +601,47 @@ def _detect_sweeps(
         if pdl:
             lower_levels_by_tf[tf].append({"type": "pdl", "price": pdl["price"], "t": pdl["t"]})  # type: ignore[index]
 
-    for timeframe, levels in upper_levels_by_tf.items():
+    diagnostics: Dict[str, Any] = {}
+
+    for timeframe in SUPPORTED_TIMEFRAMES:
         frame_payload = frames.get(timeframe)
         source_label = _frame_source(frame_payload) or "unknown"
         candles = _extract_candles(frame_payload)
+        upper_levels = upper_levels_by_tf.get(timeframe, [])
+        lower_levels = lower_levels_by_tf.get(timeframe, [])
+
+        frame_diag = {
+            "used_source": source_label,
+            "candles": len(candles),
+            "atr_period": config.atr_period,
+            "atr_mult": config.sweep_atr_multiplier,
+            "tick_size": tick_size,
+            "upper": {"levels": len(upper_levels), "events": 0, "reasons": []},
+            "lower": {"levels": len(lower_levels), "events": 0, "reasons": []},
+        }
+        diagnostics[timeframe] = frame_diag
+
+        if not upper_levels:
+            _append_reason(frame_diag["upper"]["reasons"], "no_levels")
+        if not lower_levels:
+            _append_reason(frame_diag["lower"]["reasons"], "no_levels")
+
         if not candles:
             LOGGER.debug(
                 "Skipping sweep evaluation due to empty frame",
                 extra={"tf": timeframe, "reason": "no_candles", "used_source": source_label},
             )
+            _append_reason(frame_diag["upper"]["reasons"], "no_candles")
+            _append_reason(frame_diag["lower"]["reasons"], "no_candles")
             continue
+
         LOGGER.debug(
             "Evaluating sweep candidates",
             extra={
                 "tf": timeframe,
                 "direction": "upper",
                 "candles": len(candles),
-                "levels": len(levels),
+                "levels": len(upper_levels),
                 "used_source": source_label,
             },
         )
@@ -551,7 +656,7 @@ def _detect_sweeps(
             epsilon = max(tick_min, atr_component)
             min_required = tick_min if tick_min and tick_min > 0 else epsilon
             atr_cap = atr_component if atr_component > 0 else None
-            for level in levels:
+            for level in upper_levels:
                 level_price = _coerce_float(level.get("price"))
                 if level_price is None:
                     continue
@@ -582,6 +687,14 @@ def _detect_sweeps(
                             "used_source": source_label,
                         },
                     )
+                    _append_reason(
+                        frame_diag["upper"]["reasons"],
+                        "tolerance_fail",
+                        level_type=level_type,
+                        overshoot=overshoot,
+                        tolerance=min_required,
+                        epsilon=epsilon,
+                    )
                     continue
                 if atr_cap is not None and overshoot > atr_cap + 1e-9:
                     LOGGER.debug(
@@ -596,6 +709,14 @@ def _detect_sweeps(
                             "used_source": source_label,
                         },
                     )
+                    _append_reason(
+                        frame_diag["upper"]["reasons"],
+                        "atr_breach",
+                        level_type=level_type,
+                        overshoot=overshoot,
+                        atr_limit=atr_cap,
+                        epsilon=epsilon,
+                    )
                     continue
                 if close >= level_price:
                     continue
@@ -608,28 +729,18 @@ def _detect_sweeps(
                         "atr_tolerance": epsilon,
                     }
                 )
+                frame_diag["upper"]["events"] += 1
 
-    for timeframe, levels in lower_levels_by_tf.items():
-        frame_payload = frames.get(timeframe)
-        source_label = _frame_source(frame_payload) or "unknown"
-        candles = _extract_candles(frame_payload)
-        if not candles:
-            LOGGER.debug(
-                "Skipping sweep evaluation due to empty frame",
-                extra={"tf": timeframe, "reason": "no_candles", "used_source": source_label},
-            )
-            continue
         LOGGER.debug(
             "Evaluating sweep candidates",
             extra={
                 "tf": timeframe,
                 "direction": "lower",
                 "candles": len(candles),
-                "levels": len(levels),
+                "levels": len(lower_levels),
                 "used_source": source_label,
             },
         )
-        atr_values = _compute_atr_series(candles, period=config.atr_period)
         for index, candle in enumerate(candles):
             low = _coerce_float(candle.get("l"))
             close = _coerce_float(candle.get("c"))
@@ -640,7 +751,7 @@ def _detect_sweeps(
             epsilon = max(tick_min, atr_component)
             min_required = tick_min if tick_min and tick_min > 0 else epsilon
             atr_cap = atr_component if atr_component > 0 else None
-            for level in levels:
+            for level in lower_levels:
                 level_price = _coerce_float(level.get("price"))
                 if level_price is None:
                     continue
@@ -671,6 +782,14 @@ def _detect_sweeps(
                             "used_source": source_label,
                         },
                     )
+                    _append_reason(
+                        frame_diag["lower"]["reasons"],
+                        "tolerance_fail",
+                        level_type=level_type,
+                        overshoot=overshoot,
+                        tolerance=min_required,
+                        epsilon=epsilon,
+                    )
                     continue
                 if atr_cap is not None and overshoot > atr_cap + 1e-9:
                     LOGGER.debug(
@@ -685,6 +804,14 @@ def _detect_sweeps(
                             "used_source": source_label,
                         },
                     )
+                    _append_reason(
+                        frame_diag["lower"]["reasons"],
+                        "atr_breach",
+                        level_type=level_type,
+                        overshoot=overshoot,
+                        atr_limit=atr_cap,
+                        epsilon=epsilon,
+                    )
                     continue
                 if close <= level_price:
                     continue
@@ -697,9 +824,10 @@ def _detect_sweeps(
                         "atr_tolerance": epsilon,
                     }
                 )
+                frame_diag["lower"]["events"] += 1
 
     sweeps.sort(key=lambda item: item.get("t", 0))
-    return sweeps
+    return sweeps, diagnostics
 
 
 def build_liquidity_snapshot(
@@ -714,7 +842,11 @@ def build_liquidity_snapshot(
     resolved_config = _resolve_config(config)
 
     augmented_frames = _augment_supported_frames(frames)
-    levels = _prepare_levels(augmented_frames, tick_size=tick_size, config=resolved_config)
+    levels, level_diagnostics = _prepare_levels(
+        augmented_frames,
+        tick_size=tick_size,
+        config=resolved_config,
+    )
 
     daily_candles = _extract_candles(augmented_frames.get("1d"))
     selection_end = None
@@ -722,9 +854,12 @@ def build_liquidity_snapshot(
         end_value = selection.get("end")
         if isinstance(end_value, (int, float)):
             selection_end = int(end_value)
-    daily_levels = _resolve_previous_day(daily_candles, reference_end_ms=selection_end)
+    daily_levels, daily_diagnostics = _resolve_previous_day(
+        daily_candles,
+        reference_end_ms=selection_end,
+    )
 
-    sweeps = _detect_sweeps(
+    sweeps, sweep_diagnostics = _detect_sweeps(
         augmented_frames,
         tick_size=tick_size,
         config=resolved_config,
@@ -743,11 +878,31 @@ def build_liquidity_snapshot(
         },
     )
 
+    diagnostics_payload = {
+        "config": {
+            "swing_window": resolved_config.swing_window,
+            "lookback": resolved_config.lookback_swings,
+            "r_ticks": resolved_config.r_ticks,
+            "atr_period": resolved_config.atr_period,
+            "sweep_atr_multiplier": resolved_config.sweep_atr_multiplier,
+            "tick_size": tick_size,
+        },
+        "levels": level_diagnostics,
+        "daily": daily_diagnostics,
+        "sweeps": sweep_diagnostics,
+        "summary": {
+            "eqh": len(levels["eqh"]),
+            "eql": len(levels["eql"]),
+            "sweeps": len(sweeps),
+        },
+    }
+
     return {
         "eqh": levels["eqh"],
         "eql": levels["eql"],
         "pdh": daily_levels["pdh"],
         "pdl": daily_levels["pdl"],
         "sweeps": sweeps,
+        "diagnostics": diagnostics_payload,
     }
 

--- a/tests/test_check_all_datas.py
+++ b/tests/test_check_all_datas.py
@@ -331,6 +331,9 @@ def test_historical_snapshot_still_populates_window(client: TestClient) -> None:
     assert "profile" in body and isinstance(body["profile"], list)
     assert "zones" in body and isinstance(body["zones"], dict)
     assert body["zones"].get("zones") is not None
+    liquidity_section = body.get("liquidity")
+    assert isinstance(liquidity_section, dict)
+    assert {"eqh", "eql", "pdh", "pdl", "sweeps"}.issubset(liquidity_section)
     assert "htf" in body and isinstance(body["htf"], dict)
     assert set(body["htf"].get("candles", {}).keys()).issuperset({"15m", "1h", "4h", "1d"})
     dq_htf = body.get("data_quality_htf")
@@ -511,6 +514,8 @@ def test_check_all_after_reload_returns_data(client: TestClient) -> None:
         == total_minutes
     )
     assert body["datas_for_last_N_hours"]["hours"] == 3
+    liquidity_section = body.get("liquidity")
+    assert isinstance(liquidity_section, dict)
     detailed_start_ms = window_start_ms
     expected_detailed_start = datetime.fromtimestamp(
         detailed_start_ms / 1000, tz=timezone.utc

--- a/tests/test_inspection_liquidity_tick_size.py
+++ b/tests/test_inspection_liquidity_tick_size.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+
+import pytest
+
+from src.services import inspection
+
+
+UTC = timezone.utc
+
+
+def _make_candle(ts: int, o: float, h: float, l: float, c: float) -> Dict[str, Any]:
+    return {"t": ts, "o": o, "h": h, "l": l, "c": c, "v": 1.0}
+
+
+def _sample_candles(base: datetime) -> List[Dict[str, Any]]:
+    specs = [
+        (100.0, 101.0, 99.0, 100.5),
+        (100.5, 102.0, 99.5, 101.2),
+        (101.2, 110.0, 100.0, 109.5),
+        (109.5, 108.0, 101.0, 102.0),
+        (102.0, 110.0, 101.5, 108.5),
+        (108.5, 107.0, 100.5, 101.0),
+        (101.0, 104.0, 100.0, 103.0),
+    ]
+    candles: List[Dict[str, Any]] = []
+    for index, (o, h, l, c) in enumerate(specs):
+        ts = int((base + timedelta(minutes=15 * index)).timestamp() * 1000)
+        candles.append(_make_candle(ts, o, h, l, c))
+    return candles
+
+
+@pytest.mark.parametrize(
+    "symbol, expected_tick",
+    [
+        ("BTCUSDT", 0.1),
+        ("ETHUSDT", 0.01),
+        ("SOLUSDT", 0.001),
+    ],
+)
+def test_inspection_liquidity_uses_hardcoded_tick_size(monkeypatch: pytest.MonkeyPatch, symbol: str, expected_tick: float) -> None:
+    base = datetime(2024, 6, 1, tzinfo=UTC)
+    candles_15m = _sample_candles(base)
+    candles_1d = [
+        _make_candle(int((base - timedelta(days=1)).timestamp() * 1000), 100.0, 105.0, 95.0, 101.0),
+        _make_candle(int(base.timestamp() * 1000), 101.0, 106.0, 96.0, 104.0),
+    ]
+
+    monkeypatch.setattr(
+        inspection,
+        "build_htf_section",
+        lambda *args, **kwargs: (
+            {"candles": {"15m": candles_15m, "1d": candles_1d}},
+            {"timeframes": {}},
+        ),
+    )
+    monkeypatch.setattr(inspection, "build_profile_package", lambda *args, **kwargs: ([], [], []))
+    monkeypatch.setattr(
+        inspection,
+        "detect_zones",
+        lambda *args, **kwargs: {"symbol": symbol, "zones": {"fvg": [], "ob": [], "inducement": [], "cisd": []}},
+    )
+    monkeypatch.setattr(
+        inspection,
+        "resolve_profile_config",
+        lambda sym, meta: {
+            "preset": None,
+            "preset_payload": None,
+            "preset_required": False,
+            "target_tf_key": "15m",
+            "tick_size": None,
+        },
+    )
+
+    selection = {"start": candles_15m[0]["t"], "end": candles_15m[-1]["t"]}
+    snapshot = {
+        "id": "snap-hft",
+        "symbol": symbol,
+        "frames": {"15m": {"candles": candles_15m}, "1d": {"candles": candles_1d}},
+        "selection": selection,
+        "agg_trades": {"status": "unavailable"},
+        "meta": {
+            "liquidity": {"r_ticks": 5, "swing_window": 1, "lookback": 20},
+        },
+    }
+
+    payload = inspection.build_inspection_payload(snapshot)
+    liquidity = payload["DATA"]["liquidity"]
+    eqh_levels = liquidity["eqh"]
+    assert eqh_levels, "Expected EQH levels to be detected for fallback tick size"
+
+    tolerance_per_tick = [level["tolerance"] / 5 for level in eqh_levels if level.get("tolerance")]
+    assert tolerance_per_tick, "Liquidity levels should report tolerance values"
+    assert any(math.isclose(value, expected_tick, rel_tol=1e-9, abs_tol=1e-9) for value in tolerance_per_tick)

--- a/tests/test_inspection_liquidity_tick_size.py
+++ b/tests/test_inspection_liquidity_tick_size.py
@@ -95,3 +95,9 @@ def test_inspection_liquidity_uses_hardcoded_tick_size(monkeypatch: pytest.Monke
     tolerance_per_tick = [level["tolerance"] / 5 for level in eqh_levels if level.get("tolerance")]
     assert tolerance_per_tick, "Liquidity levels should report tolerance values"
     assert any(math.isclose(value, expected_tick, rel_tol=1e-9, abs_tol=1e-9) for value in tolerance_per_tick)
+
+    diagnostics = payload["DIAGNOSTICS"].get("liquidity")
+    assert isinstance(diagnostics, dict)
+    summary = diagnostics.get("summary")
+    assert isinstance(summary, dict)
+    assert summary.get("eqh") >= 0

--- a/tests/test_liquidity.py
+++ b/tests/test_liquidity.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+
+from src.services.liquidity import build_liquidity_snapshot
+
+
+UTC = timezone.utc
+
+
+def _make_candle(ts: int, o: float, h: float, l: float, c: float) -> dict[str, float]:
+    return {"t": ts, "o": o, "h": h, "l": l, "c": c, "v": 1.0}
+
+
+def test_liquidity_detects_equal_levels_and_sweeps() -> None:
+    base = datetime(2024, 1, 1, tzinfo=UTC)
+    candles_15m = [
+        _make_candle(int((base + timedelta(minutes=15 * idx)).timestamp() * 1000), *values)
+        for idx, values in enumerate(
+            [
+                (100.0, 100.5, 97.0, 99.0),
+                (99.0, 102.0, 98.0, 101.0),
+                (101.0, 105.0, 100.0, 104.0),  # swing high
+                (104.0, 104.2, 95.0, 96.0),   # swing low
+                (96.0, 104.95, 95.3, 103.0),  # swing high close to previous
+                (103.0, 103.5, 95.1, 96.5),   # swing low close to previous
+                (96.5, 99.0, 95.8, 98.0),
+                (98.0, 99.5, 96.7, 99.0),
+                (99.0, 105.3, 99.0, 104.2),   # sweep top candle
+                (104.2, 105.0, 94.8, 95.6),   # sweep bottom candle
+            ]
+        )
+    ]
+
+    day_base = datetime(2023, 12, 31, tzinfo=UTC)
+    candles_1d = [
+        _make_candle(int((day_base + timedelta(days=offset)).timestamp() * 1000), *values)
+        for offset, values in enumerate(
+            [
+                (100.0, 105.0, 95.0, 102.0),
+                (102.0, 111.0, 91.0, 109.0),  # previous day
+                (109.0, 112.0, 100.0, 105.0),
+            ]
+        )
+    ]
+
+    selection_end = int((base + timedelta(days=2, hours=12)).timestamp() * 1000)
+    frames = {"15m": {"candles": candles_15m}, "1d": {"candles": candles_1d}}
+
+    liquidity = build_liquidity_snapshot(
+        frames,
+        tick_size=0.1,
+        selection={"end": selection_end},
+        config={
+            "r_ticks": 2,
+            "lookback": 10,
+            "swing_window": 1,
+            "atr_period": 3,
+            "sweep_atr_multiplier": 1.5,
+        },
+    )
+
+    expected_day = candles_1d[2]
+    assert liquidity["pdh"] == {
+        "t": expected_day["t"],
+        "price": expected_day["h"],
+    }
+    assert liquidity["pdl"] == {
+        "t": expected_day["t"],
+        "price": expected_day["l"],
+    }
+
+    eqh_levels = liquidity["eqh"]
+    eql_levels = liquidity["eql"]
+    assert len(eqh_levels) == 1
+    assert len(eql_levels) == 1
+
+    eqh = eqh_levels[0]
+    eql = eql_levels[0]
+    assert eqh["tf"] == "15m"
+    assert eql["tf"] == "15m"
+    eqh_swings = set(eqh["swings"])
+    eql_swings = set(eql["swings"])
+    assert {candles_15m[2]["t"], candles_15m[4]["t"]}.issubset(eqh_swings)
+    assert {candles_15m[3]["t"], candles_15m[5]["t"]}.issubset(eql_swings)
+    assert abs(eqh["price"] - 105.0) < 0.2
+    assert abs(eql["price"] - 95.05) < 0.2
+    assert eqh["tolerance"] == 0.2
+    assert eql["tolerance"] == 0.2
+
+    sweep_types = {event["type"] for event in liquidity["sweeps"]}
+    level_types = {event["level_type"] for event in liquidity["sweeps"]}
+    assert sweep_types == {"sweep_top", "sweep_bottom"}
+    assert level_types == {"eqh", "eql"}
+    for event in liquidity["sweeps"]:
+        assert event["atr_tolerance"] >= 0
+
+
+def test_liquidity_respects_atr_tolerance() -> None:
+    base = datetime(2024, 5, 1, tzinfo=UTC)
+    highs = [100.2, 100.4, 100.6, 100.3, 100.62, 100.35, 101.1]
+    lows = [99.8, 100.0, 100.2, 100.1, 100.3, 100.2, 99.5]
+    closes = [100.0, 100.2, 100.5, 100.2, 100.58, 100.25, 100.0]
+    candles = []
+    for idx in range(len(highs)):
+        ts = int((base + timedelta(minutes=15 * idx)).timestamp() * 1000)
+        candles.append(_make_candle(ts, closes[idx], highs[idx], lows[idx], closes[idx]))
+
+    frames = {"15m": {"candles": candles}}
+    liquidity = build_liquidity_snapshot(
+        frames,
+        tick_size=0.01,
+        config={
+            "r_ticks": 2,
+            "lookback": 10,
+            "swing_window": 1,
+            "atr_period": 3,
+            "sweep_atr_multiplier": 0.1,
+        },
+    )
+
+    # Equal highs should still be detected, but sweep should be filtered out.
+    assert liquidity["eqh"]
+    assert liquidity["sweeps"] == []
+

--- a/tests/test_liquidity.py
+++ b/tests/test_liquidity.py
@@ -12,6 +12,26 @@ def _make_candle(ts: int, o: float, h: float, l: float, c: float) -> dict[str, f
     return {"t": ts, "o": o, "h": h, "l": l, "c": c, "v": 1.0}
 
 
+def _expand_block_to_minutes(start: datetime, o: float, h: float, l: float, c: float) -> list[dict[str, float]]:
+    candles: list[dict[str, float]] = []
+    for minute in range(15):
+        moment = start + timedelta(minutes=minute)
+        ts = int(moment.timestamp() * 1000)
+        open_price = o if minute == 0 else c
+        close_price = c
+        high_price = h if minute == 0 else max(c, o)
+        low_price = l if minute == 0 else min(c, o)
+        candles.append({
+            "t": ts,
+            "o": open_price,
+            "h": high_price,
+            "l": low_price,
+            "c": close_price,
+            "v": 1.0,
+        })
+    return candles
+
+
 def test_liquidity_detects_equal_levels_and_sweeps() -> None:
     base = datetime(2024, 1, 1, tzinfo=UTC)
     candles_15m = [
@@ -122,4 +142,102 @@ def test_liquidity_respects_atr_tolerance() -> None:
     # Equal highs should still be detected, but sweep should be filtered out.
     assert liquidity["eqh"]
     assert liquidity["sweeps"] == []
+
+
+def test_liquidity_aggregates_minute_seed() -> None:
+    base = datetime(2024, 2, 1, tzinfo=UTC)
+    minute_candles: list[dict[str, float]] = []
+    fifteen_specs = [
+        (100.0, 100.5, 97.0, 99.0),
+        (99.0, 102.0, 98.0, 101.0),
+        (101.0, 105.0, 100.0, 104.0),
+        (104.0, 104.2, 95.0, 96.0),
+        (96.0, 104.95, 95.3, 103.0),
+        (103.0, 103.5, 95.1, 96.5),
+        (96.5, 99.0, 95.8, 98.0),
+        (98.0, 99.5, 96.7, 99.0),
+        (99.0, 105.3, 99.0, 104.2),
+        (104.2, 105.0, 94.8, 95.6),
+    ]
+    for idx, spec in enumerate(fifteen_specs):
+        block_start = base + timedelta(minutes=15 * idx)
+        minute_candles.extend(_expand_block_to_minutes(block_start, *spec))
+
+    day_base = datetime(2024, 1, 31, tzinfo=UTC)
+    candles_1d = [
+        _make_candle(int((day_base + timedelta(days=offset)).timestamp() * 1000), *values)
+        for offset, values in enumerate(
+            [
+                (100.0, 105.0, 95.0, 102.0),
+                (102.0, 111.0, 91.0, 109.0),
+                (109.0, 112.0, 100.0, 105.0),
+            ]
+        )
+    ]
+
+    selection_end = int((base + timedelta(days=2)).timestamp() * 1000)
+    frames = {"1m": {"candles": minute_candles}, "1d": {"candles": candles_1d}}
+
+    liquidity = build_liquidity_snapshot(
+        frames,
+        tick_size=0.1,
+        selection={"end": selection_end},
+        config={
+            "r_ticks": 2,
+            "lookback": 10,
+            "swing_window": 1,
+            "atr_period": 3,
+            "sweep_atr_multiplier": 1.5,
+        },
+    )
+
+    assert liquidity["eqh"]
+    assert liquidity["eql"]
+    sweep_types = {event["type"] for event in liquidity["sweeps"]}
+    assert "sweep_top" in sweep_types
+    assert "sweep_bottom" in sweep_types
+
+
+def test_liquidity_detects_pdh_pdl_sweeps_from_minute_seed() -> None:
+    base = datetime(2024, 3, 2, tzinfo=UTC)
+    minute_candles: list[dict[str, float]] = []
+    blocks = [
+        (200.0, 205.0, 198.0, 203.0),
+        (203.0, 206.5, 200.0, 204.5),
+        (204.5, 221.5, 203.5, 219.0),  # sweep top above PDH
+        (219.0, 220.0, 178.5, 181.0),  # sweep bottom below PDL
+        (181.0, 190.0, 180.0, 188.0),
+    ]
+    for idx, spec in enumerate(blocks):
+        block_start = base + timedelta(minutes=15 * idx)
+        minute_candles.extend(_expand_block_to_minutes(block_start, *spec))
+
+    previous_day = datetime(2024, 3, 1, tzinfo=UTC)
+    candles_1d = [
+        _make_candle(int(previous_day.timestamp() * 1000), 195.0, 220.0, 180.0, 210.0),
+        _make_candle(int((previous_day + timedelta(days=1)).timestamp() * 1000), 210.0, 212.0, 190.0, 200.0),
+    ]
+
+    selection_end = int((base + timedelta(hours=6)).timestamp() * 1000)
+    frames = {"1m": {"candles": minute_candles}, "1d": {"candles": candles_1d}}
+
+    liquidity = build_liquidity_snapshot(
+        frames,
+        tick_size=1.0,
+        selection={"end": selection_end},
+        config={
+            "r_ticks": 2,
+            "lookback": 10,
+            "swing_window": 1,
+            "atr_period": 5,
+            "sweep_atr_multiplier": 2.0,
+        },
+    )
+
+    sweeps = liquidity["sweeps"]
+    assert sweeps
+    level_types = {event["level_type"] for event in sweeps}
+    assert level_types == {"pdh", "pdl"}
+    types = {event["type"] for event in sweeps}
+    assert types == {"sweep_top", "sweep_bottom"}
 

--- a/tests/test_liquidity.py
+++ b/tests/test_liquidity.py
@@ -115,6 +115,22 @@ def test_liquidity_detects_equal_levels_and_sweeps() -> None:
     for event in liquidity["sweeps"]:
         assert event["atr_tolerance"] >= 0
 
+    diagnostics = liquidity.get("diagnostics")
+    assert isinstance(diagnostics, dict)
+    summary = diagnostics.get("summary")
+    assert isinstance(summary, dict)
+    assert summary.get("eqh") == len(eqh_levels)
+    levels_diag = diagnostics.get("levels")
+    assert isinstance(levels_diag, dict)
+    tf_diag = levels_diag.get("15m")
+    assert isinstance(tf_diag, dict)
+    eqh_diag = tf_diag.get("eqh")
+    eql_diag = tf_diag.get("eql")
+    assert isinstance(eqh_diag, dict)
+    assert isinstance(eql_diag, dict)
+    assert eqh_diag.get("cluster_count") == len(eqh_levels)
+    assert eql_diag.get("cluster_count") == len(eql_levels)
+
 
 def test_liquidity_respects_atr_tolerance() -> None:
     base = datetime(2024, 5, 1, tzinfo=UTC)
@@ -142,6 +158,13 @@ def test_liquidity_respects_atr_tolerance() -> None:
     # Equal highs should still be detected, but sweep should be filtered out.
     assert liquidity["eqh"]
     assert liquidity["sweeps"] == []
+
+    diagnostics = liquidity.get("diagnostics")
+    assert isinstance(diagnostics, dict)
+    summary = diagnostics.get("summary")
+    assert isinstance(summary, dict)
+    assert summary.get("sweeps") == 0
+
 
 
 def test_liquidity_aggregates_minute_seed() -> None:
@@ -196,6 +219,12 @@ def test_liquidity_aggregates_minute_seed() -> None:
     sweep_types = {event["type"] for event in liquidity["sweeps"]}
     assert "sweep_top" in sweep_types
     assert "sweep_bottom" in sweep_types
+
+    diagnostics = liquidity.get("diagnostics")
+    assert isinstance(diagnostics, dict)
+    summary = diagnostics.get("summary")
+    assert isinstance(summary, dict)
+    assert summary.get("eqh") == len(liquidity["eqh"])
 
 
 def test_liquidity_detects_pdh_pdl_sweeps_from_minute_seed() -> None:

--- a/tests/test_ohlc_resample.py
+++ b/tests/test_ohlc_resample.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.services.ohlc import TIMEFRAME_TO_MS, resample_ohlcv
+
+UTC = timezone.utc
+
+
+def _minute_block(start: datetime, o: float, h: float, l: float, c: float, *, minutes: int = 15):
+    candles = []
+    for offset in range(minutes):
+        ts = int((start + timedelta(minutes=offset)).timestamp() * 1000)
+        open_price = o if offset == 0 else c
+        close_price = c
+        high_price = h if offset == 0 else max(c, o)
+        low_price = l if offset == 0 else min(c, o)
+        candles.append({
+            "t": ts,
+            "o": open_price,
+            "h": high_price,
+            "l": low_price,
+            "c": close_price,
+            "v": 1.0,
+        })
+    return candles
+
+
+def test_resample_builds_expected_15m_and_1h_buckets():
+    base = datetime(2024, 1, 1, tzinfo=UTC)
+    minute_candles = []
+    specs = [
+        (100.0, 105.0, 99.5, 102.0),
+        (102.0, 106.0, 101.0, 104.0),
+        (104.0, 110.0, 103.0, 108.0),
+        (108.0, 112.0, 107.0, 111.0),
+    ]
+    for index, spec in enumerate(specs):
+        start = base + timedelta(minutes=15 * index)
+        minute_candles.extend(_minute_block(start, *spec))
+
+    resampled_15m = resample_ohlcv(minute_candles, TIMEFRAME_TO_MS["15m"])
+    assert len(resampled_15m) == len(specs)
+    first = resampled_15m[0]
+    assert first["t"] == int(base.timestamp() * 1000)
+    assert pytest.approx(first["o"]) == 100.0
+    assert pytest.approx(first["h"]) == 105.0
+    assert pytest.approx(first["l"]) == 99.5
+    assert pytest.approx(first["c"]) == 102.0
+    assert pytest.approx(first["v"]) == 15.0
+
+    resampled_1h = resample_ohlcv(minute_candles, TIMEFRAME_TO_MS["1h"])
+    assert len(resampled_1h) == 1
+    hourly = resampled_1h[0]
+    assert hourly["t"] == int(base.timestamp() * 1000)
+    assert pytest.approx(hourly["o"]) == 100.0
+    assert pytest.approx(hourly["h"]) == 112.0
+    assert pytest.approx(hourly["l"]) == 99.5
+    assert pytest.approx(hourly["c"]) == 111.0
+    assert pytest.approx(hourly["v"]) == 60.0


### PR DESCRIPTION
## Summary
- implement a liquidity detection module that clusters swing highs/lows and identifies sweeps across supported timeframes
- integrate the computed liquidity payload into the inspection response and expose the builder from the services package
- add regression tests covering equal level clustering, PDH/PDL resolution, and ATR-based sweep filtering

## Testing
- PYTHONPATH=. pytest tests/test_liquidity.py

------
https://chatgpt.com/codex/tasks/task_e_68d81c4396bc8324b3d6a04ed94ee9ef