### PR TITLE
feat: enrich inspection payload with advanced analytics

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -37,6 +37,8 @@ from ..services import (
     save_preset,
     set_last_collection_time,
     update_preset,
+    apply_enrichment_to_payload,
+    enrich_inspection_snapshot,
 )
 from ..services.zones import Config as ZonesConfig, detect_zones
 
@@ -510,6 +512,15 @@ async def register_inspection_snapshot(payload: SnapshotIn) -> Dict[str, str]:
     snapshot["book"] = book_state
     snapshot["news_events"] = news_items
 
+    enrichment: Dict[str, Any] | None = None
+    try:
+        enrichment = await enrich_inspection_snapshot(snapshot, cache=cache)
+    except Exception as exc:
+        logging.getLogger(__name__).warning("Snapshot enrichment failed: %s", exc)
+        enrichment = {"status": "insufficient_data", "missing_fields": [str(exc)]}
+    if enrichment:
+        snapshot["enrichment"] = enrichment
+
     valid, errors = validate_enhanced_snapshot(snapshot)
     if not valid:
         raise HTTPException(status_code=422, detail={"errors": errors})
@@ -729,12 +740,28 @@ async def inspection(
 
     payload = build_inspection_payload(target_snapshot)
 
-    enriched = getattr(app.state, "snapshots", {}).get(target_snapshot.get("id")) if isinstance(target_snapshot, Mapping) else None
-    if isinstance(enriched, Mapping):
+    stored_snapshots = getattr(app.state, "snapshots", {})
+    enriched_snapshot = stored_snapshots.get(target_snapshot.get("id")) if isinstance(stored_snapshots, Mapping) else None
+    if isinstance(enriched_snapshot, Mapping):
+        enrichment_payload = enriched_snapshot.get("enrichment") if isinstance(enriched_snapshot.get("enrichment"), Mapping) else None
+        if enrichment_payload is None:
+            try:
+                cache = getattr(app.state, "ohlcv_cache", {})
+                combined_snapshot = dict(enriched_snapshot)
+                data_section = payload.get("DATA") if isinstance(payload.get("DATA"), Mapping) else None
+                if data_section is not None:
+                    combined_snapshot["DATA"] = data_section
+                enrichment_payload = await enrich_inspection_snapshot(combined_snapshot, cache=cache)
+                enriched_snapshot["enrichment"] = enrichment_payload
+            except Exception as exc:
+                logging.getLogger(__name__).warning("Inspection enrichment failed: %s", exc)
+                enrichment_payload = None
         data_section = payload.setdefault("DATA", {})
         for key in ("ohlcv", "orderflow", "liquidity_map", "derivatives", "book", "news_events"):
-            if key in enriched and key not in data_section:
-                data_section[key] = enriched[key]
+            if key in enriched_snapshot and key not in data_section:
+                data_section[key] = enriched_snapshot[key]
+        if enrichment_payload:
+            apply_enrichment_to_payload(payload, enrichment_payload)
 
     accept_header = request.headers.get("accept", "").lower()
     if "application/json" in accept_header:

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -905,6 +905,7 @@ async def inspection_check_all(
     if mode_value == "topup":
         last_collection = get_last_collection_time()
         window_hours = 4
+        window_start_override_ms: int | None = None
         if last_collection is not None:
             delta = collection_reference - last_collection
             delta_seconds = max(delta.total_seconds(), 0)
@@ -915,11 +916,18 @@ async def inspection_check_all(
                 window_hours = 4
             else:
                 window_hours = max(1, int(ceil(delta_hours)))
+            last_collection_utc = last_collection.astimezone(timezone.utc)
+            last_collection_ms = int(last_collection_utc.timestamp() * 1000)
+            aligned_ms = (last_collection_ms // 60_000) * 60_000
+            next_minute_ms = aligned_ms + 60_000
+            window_start_override_ms = max(0, next_minute_ms)
         try:
             payload = build_check_all_datas(
                 target_snapshot,
                 now_utc=now_override,
                 window_hours=window_hours,
+                window_start_override_ms=window_start_override_ms,
+                strict_window=True,
             )
         except DataQualityError as exc:
             raise HTTPException(

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -31,6 +31,7 @@ from .presets import (
 )
 from .liquidity import build_liquidity_snapshot
 from .zones import Config as ZonesConfig, detect_zones
+from .enrichment import apply_enrichment_to_payload, enrich_inspection_snapshot
 from .collection_state import get_last_collection_time, set_last_collection_time
 from .shared_candles_store import (
     clear_shared_candles,
@@ -92,4 +93,6 @@ __all__ = [
     "get_shared_candles",
     "merge_shared_candles",
     "clear_shared_candles",
+    "enrich_inspection_snapshot",
+    "apply_enrichment_to_payload",
 ]

--- a/src/services/check_all_datas.py
+++ b/src/services/check_all_datas.py
@@ -1858,6 +1858,8 @@ def build_check_all_datas(
     selection_end_ms: int | None = None,
     hours: int | None = None,
     window_hours: int | None = None,
+    window_start_override_ms: int | None = None,
+    strict_window: bool = False,
 ) -> Dict[str, Any] | None:
     """Create an enriched payload for the snapshot health endpoint."""
 
@@ -1957,15 +1959,6 @@ def build_check_all_datas(
     if selection_start > selection_end:
         selection_start, selection_end = selection_end, selection_start
 
-    if window_hours is not None:
-        try:
-            hours_candidate = int(window_hours)
-        except (TypeError, ValueError):
-            hours_candidate = 0
-        hours_window = max(1, hours_candidate)
-    else:
-        hours_window = hours if hours in VALID_HOUR_WINDOWS else min(VALID_HOUR_WINDOWS)
-
     if now_utc is not None:
         if now_utc.tzinfo is None:
             now_dt = now_utc.replace(tzinfo=UTC)
@@ -1990,10 +1983,42 @@ def build_check_all_datas(
 
     window_end_ms = max(0, _align_to_interval(window_end_ms, MINUTE_INTERVAL_MS))
 
-    raw_window_start = window_end_ms - hours_window * MS_IN_HOUR
-    window_start_ms = max(0, _align_to_interval(raw_window_start, MINUTE_INTERVAL_MS))
-    if target_interval_ms > MINUTE_INTERVAL_MS:
-        window_start_ms = max(0, _align_to_interval(window_start_ms, target_interval_ms))
+    if window_hours is not None:
+        try:
+            hours_candidate = int(window_hours)
+        except (TypeError, ValueError):
+            hours_candidate = 0
+        hours_window = max(1, hours_candidate)
+    else:
+        hours_window = hours if hours in VALID_HOUR_WINDOWS else min(VALID_HOUR_WINDOWS)
+
+    override_start_ms: int | None = None
+    if window_start_override_ms is not None:
+        try:
+            override_start_ms = int(window_start_override_ms)
+        except (TypeError, ValueError):
+            override_start_ms = None
+        if override_start_ms is not None:
+            override_start_ms = max(0, override_start_ms)
+
+    if override_start_ms is not None:
+        window_start_ms = max(0, _align_to_interval(override_start_ms, MINUTE_INTERVAL_MS))
+        if window_start_ms >= window_end_ms:
+            window_start_ms = max(0, window_end_ms - MINUTE_INTERVAL_MS)
+        if target_interval_ms > MINUTE_INTERVAL_MS and not strict_window:
+            aligned_target = _align_to_interval(window_start_ms, target_interval_ms)
+            if aligned_target < window_start_ms:
+                aligned_target += target_interval_ms
+            if aligned_target >= window_end_ms:
+                aligned_target = max(0, window_end_ms - target_interval_ms)
+            window_start_ms = max(0, aligned_target)
+        span_ms = max(MINUTE_INTERVAL_MS, window_end_ms - window_start_ms + MINUTE_INTERVAL_MS)
+        hours_window = max(1, int(math.ceil(span_ms / MS_IN_HOUR)))
+    else:
+        raw_window_start = window_end_ms - hours_window * MS_IN_HOUR
+        window_start_ms = max(0, _align_to_interval(raw_window_start, MINUTE_INTERVAL_MS))
+        if target_interval_ms > MINUTE_INTERVAL_MS:
+            window_start_ms = max(0, _align_to_interval(window_start_ms, target_interval_ms))
 
     minute_index_all = {candle["t"]: candle for candle in minute_candles}
     minute_window_index = {
@@ -2056,26 +2081,38 @@ def build_check_all_datas(
     frames["1m"] = [minute_index_all[ts] for ts in sorted(minute_index_all)]
     minute_candles = frames["1m"]
 
-    zones_window_hours = max(48, hours_window)
+    zones_window_hours = max(1, hours_window)
+    if not strict_window:
+        zones_window_hours = max(48, zones_window_hours)
     fifteen_min_ms = TIMEFRAME_TO_MS.get("15m") or 15 * MINUTE_INTERVAL_MS
-    zone_window_ms = zones_window_hours * MS_IN_HOUR
-    raw_zone_start = max(0, window_end_ms - zone_window_ms)
-    if fifteen_min_ms:
-        raw_zone_start = max(0, _align_to_interval(raw_zone_start, fifteen_min_ms))
-    zones_window_start_ms = raw_zone_start
+    if strict_window:
+        zones_window_start_ms = max(0, _align_to_interval(window_start_ms, MINUTE_INTERVAL_MS))
+    else:
+        zone_window_ms = zones_window_hours * MS_IN_HOUR
+        raw_zone_start = max(0, window_end_ms - zone_window_ms)
+        if fifteen_min_ms:
+            raw_zone_start = max(0, _align_to_interval(raw_zone_start, fifteen_min_ms))
+        zones_window_start_ms = raw_zone_start
     warmup_bars_base = zone_cfg.atr_period + 10
     min_bars_per_tf = {"15m": 200, "1h": 60, "4h": 24}
+    required_bars_per_tf: Dict[str, int] = {}
     history_candidate = zones_window_start_ms
     for tf_key, baseline in min_bars_per_tf.items():
         required = max(baseline, warmup_bars_base)
+        required_bars_per_tf[tf_key] = required
+        if strict_window:
+            continue
         interval_ms_tf = TIMEFRAME_TO_MS.get(tf_key)
         if not interval_ms_tf:
             continue
         candidate = zones_window_start_ms - required * interval_ms_tf
         if candidate < history_candidate:
             history_candidate = candidate
-    history_candidate = min(history_candidate, zones_window_start_ms - MS_IN_DAY)
-    zones_history_start_ms = max(0, history_candidate)
+    if strict_window:
+        zones_history_start_ms = zones_window_start_ms
+    else:
+        history_candidate = min(history_candidate, zones_window_start_ms - MS_IN_DAY)
+        zones_history_start_ms = max(0, history_candidate)
     zones_history_start_ms = max(0, _align_to_interval(zones_history_start_ms, MINUTE_INTERVAL_MS))
 
     zone_expected_minutes = _build_expected_times(
@@ -2162,6 +2199,15 @@ def build_check_all_datas(
         total = len(zone_frames_full.get(tf, []))
         window_count = len(zone_frames_window.get(tf, []))
         warmup_bars_per_tf[tf] = max(0, total - window_count)
+    zone_availability: Dict[str, Dict[str, int | bool]] = {}
+    if strict_window:
+        for tf_key, required in required_bars_per_tf.items():
+            available = len(zone_frames_window.get(tf_key, []))
+            zone_availability[tf_key] = {
+                "required": int(required),
+                "available": int(available),
+                "ok": bool(available >= required),
+            }
     zones_diag = {
         "tf_lengths": zone_tf_lengths,
         "atr_period": zone_cfg.atr_period,
@@ -2169,6 +2215,8 @@ def build_check_all_datas(
         "window_hours": zones_window_hours,
         "tick_size": zone_cfg.tick_size,
     }
+    if zone_availability:
+        zones_diag["availability"] = zone_availability
     zone_cfg.zones_window_start_ms = zones_window_start_ms
     zone_cfg.window_end_ms_prev_closed = window_end_ms
     zone_cfg.allow_base_fallback = True
@@ -2523,6 +2571,16 @@ def build_check_all_datas(
                 if rb_fallback_map:
                     zones_diag["base_fallback_used"] = rb_fallback_map
                 zones_diag["detection"] = detection_diag
+    zone_type_timeframes = {
+        "fvg": ("15m", "1h", "4h"),
+        "ob": ("15m", "1h", "4h"),
+        "mb": ("1h", "4h"),
+        "bb": ("1h", "4h"),
+        "rb": ("15m", "1h", "4h"),
+        "pb": ("15m", "1h", "4h"),
+        "sr": ("1h", "4h"),
+    }
+
     if isinstance(zones_container, MutableMapping):
         timestamp_filters = {
             "fvg": "created_utc",
@@ -2574,6 +2632,13 @@ def build_check_all_datas(
                     "window_hours": zones_window_hours,
                 },
             )
+
+    if strict_window and zone_availability and isinstance(zones_container, MutableMapping):
+        for zone_key, tf_candidates in zone_type_timeframes.items():
+            if not tf_candidates or zone_key not in zones_container:
+                continue
+            if any(not zone_availability.get(tf, {}).get("ok", False) for tf in tf_candidates):
+                zones_container[zone_key] = []
 
     liquidity_payload = build_liquidity_snapshot(
         liquidity_frames,
@@ -2952,6 +3017,35 @@ def build_check_all_datas(
                 zones_public[key] = [
                     dict(item) for item in raw_zone if isinstance(item, Mapping)
                 ]
+
+    if strict_window and zone_availability:
+        for zone_key, tf_candidates in zone_type_timeframes.items():
+            if zones_public.get(zone_key):
+                continue
+            if not tf_candidates:
+                continue
+            insufficient: List[str] = []
+            tracked = 0
+            for tf_name in tf_candidates:
+                tracked += 1
+                info = zone_availability.get(tf_name)
+                required = required_bars_per_tf.get(tf_name, 0)
+                available = len(zone_frames_window.get(tf_name, []))
+                ok = available >= required if required else False
+                if info is not None:
+                    required = int(info.get("required", required))
+                    available = int(info.get("available", available))
+                    ok = bool(info.get("ok", available >= required if required else False))
+                if not required:
+                    continue
+                if not ok:
+                    insufficient.append(f"{tf_name}: {available}/{required}")
+            if tracked and insufficient and len(insufficient) == tracked:
+                message = (
+                    f"В выбранный период данных для {zone_key.upper()} нет "
+                    f"(доступно {', '.join(insufficient)})."
+                )
+                zones_public[zone_key] = [{"message": message, "period": "topup"}]
 
     liquidity_public = {
         "eqh": list(liquidity_equal_levels.get("eqh", [])),

--- a/src/services/enrichment.py
+++ b/src/services/enrichment.py
@@ -1,0 +1,394 @@
+"""Utilities to enrich inspection payloads with SMC/ICT metrics."""
+from __future__ import annotations
+
+import asyncio
+import statistics
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+import httpx
+BINANCE_KLINES_URL = "https://api.binance.com/api/v3/klines"
+MAX_DELTA_BARS = 50; MAX_FOOTPRINT_ROWS = 10
+
+
+def _parse_ts(value: Any) -> Optional[int]:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            if "T" in value:
+                return int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp() * 1000)
+            return int(float(value))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _normalise_row(row: Mapping[str, Any]) -> Optional[Dict[str, float]]:
+    ts = _parse_ts(row.get("t") or row.get("time") or row.get("openTime"))
+    if ts is None:
+        return None
+    try:
+        o = float(row.get("o") or row.get("open"))
+        h = float(row.get("h") or row.get("high"))
+        l = float(row.get("l") or row.get("low"))
+        c = float(row.get("c") or row.get("close"))
+        v = float(row.get("v") or row.get("volume") or 0.0)
+    except (TypeError, ValueError):
+        return None
+    return {"t": ts, "o": o, "h": h, "l": l, "c": c, "v": max(v, 0.0)}
+
+
+def _map_minutes(rows: Iterable[Mapping[str, Any]]) -> Dict[int, Dict[str, float]]:
+    minutes: Dict[int, Dict[str, float]] = {}
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        candle = _normalise_row(row)
+        if candle is not None:
+            minutes[candle["t"]] = candle
+    return minutes
+
+
+async def _fetch_recent(symbol: str, interval: str, limit: int) -> List[Dict[str, float]]:
+    params = {"symbol": symbol.upper(), "interval": interval, "limit": str(min(max(limit, 1), 1000))}
+    async with httpx.AsyncClient(timeout=httpx.Timeout(15.0)) as client:
+        response = await client.get(BINANCE_KLINES_URL, params=params)
+        response.raise_for_status()
+        payload = response.json()
+    candles: List[Dict[str, float]] = []
+    if isinstance(payload, Sequence):
+        for row in payload:
+            try:
+                candles.append({
+                    "t": int(row[0]),
+                    "o": float(row[1]),
+                    "h": float(row[2]),
+                    "l": float(row[3]),
+                    "c": float(row[4]),
+                    "v": max(float(row[5]), 0.0),
+                })
+            except (IndexError, TypeError, ValueError):
+                continue
+    return candles
+
+
+def _zone_state(series: Sequence[Mapping[str, float]], idx: int, direction: str) -> str:
+    base = series[idx]
+    body_low = min(base["o"], base["c"])
+    body_high = max(base["o"], base["c"])
+    tapped = False
+    for candle in series[idx + 1 :]:
+        low = candle.get("l", body_low)
+        high = candle.get("h", body_high)
+        if direction == "demand":
+            if low < body_low:
+                return "invalidated"
+            if low <= body_high <= high:
+                tapped = True
+        else:
+            if high > body_high:
+                return "invalidated"
+            if high >= body_low >= low:
+                tapped = True
+    return "tapped" if tapped else "fresh"
+
+
+def _supply_demand(candles: Sequence[Mapping[str, float]]) -> Dict[str, List[Dict[str, Any]]]:
+    avg = statistics.fmean([float(c.get("v", 0.0)) for c in candles]) if candles else 0.0
+    result = {"demand": [], "supply": []}
+    for idx, candle in enumerate(candles):
+        if avg and candle.get("v", 0.0) < avg:
+            continue
+        direction = "demand" if candle.get("c", 0.0) >= candle.get("o", 0.0) else "supply"
+        zone = {
+            "open": float(min(candle.get("o", 0.0), candle.get("c", 0.0))),
+            "close": float(max(candle.get("o", 0.0), candle.get("c", 0.0))),
+            "mean": float((candle.get("o", 0.0) + candle.get("h", 0.0) + candle.get("l", 0.0) + candle.get("c", 0.0)) / 4),
+            "origin_utc": datetime.fromtimestamp(candle["t"] / 1000, tz=timezone.utc).isoformat().replace("+00:00", "Z"),
+            "status": _zone_state(candles, idx, direction),
+        }
+        result[direction].append(zone)
+    return result
+
+
+def _delta_series(candles: Iterable[Mapping[str, float]]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for candle in list(candles)[-MAX_DELTA_BARS:]:
+        spread = max(float(candle.get("h", 0.0)) - float(candle.get("l", 0.0)), 1e-9)
+        change = float(candle.get("c", 0.0)) - float(candle.get("o", 0.0))
+        volume = float(candle.get("v", 0.0))
+        rows.append({"t": int(candle.get("t", 0)), "delta": volume * (change / spread)})
+    return rows
+
+
+def _cvd(delta_rows: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    running = 0.0
+    series: List[Dict[str, Any]] = []
+    for row in delta_rows:
+        running += float(row.get("delta", 0.0))
+        series.append({"t": row.get("t"), "cvd": running})
+    return series
+
+
+def _footprint_summary(footprint: Sequence[Mapping[str, Any]], minute_map: Mapping[int, Mapping[str, float]]) -> List[Dict[str, Any]]:
+    grouped: Dict[int, Dict[str, float]] = defaultdict(lambda: {"buy": 0.0, "sell": 0.0})
+    for row in footprint:
+        ts = _parse_ts(row.get("t"))
+        if ts is None:
+            continue
+        grouped[ts]["buy"] += max(float(row.get("ask", 0.0)), 0.0)
+        grouped[ts]["sell"] += max(float(row.get("bid", 0.0)), 0.0)
+    summaries: List[Dict[str, Any]] = []
+    for ts in sorted(grouped)[-MAX_FOOTPRINT_ROWS:]:
+        totals = grouped[ts]
+        total_vol = totals["buy"] + totals["sell"]
+        candle = minute_map.get(ts, {})
+        price_span = max(float(candle.get("h", 0.0)) - float(candle.get("l", 0.0)), 1e-9)
+        price_move = float(candle.get("c", 0.0)) - float(candle.get("o", 0.0))
+        buy_share = (totals["buy"] / total_vol * 100.0) if total_vol else 0.0
+        sell_share = (totals["sell"] / total_vol * 100.0) if total_vol else 0.0
+        imbalance = abs(totals["buy"] - totals["sell"])
+        summaries.append({
+            "t": ts,
+            "buy_imbalance": round(buy_share, 3),
+            "sell_imbalance": round(sell_share, 3),
+            "absorption": bool(total_vol and imbalance > 0.55 * total_vol and abs(price_move) < 0.25 * price_span),
+        })
+    return summaries
+
+
+def _block_candidates(candles: Sequence[Mapping[str, float]], tf: str, *, min_ratio: float) -> List[Dict[str, Any]]:
+    if len(candles) < 5:
+        return []
+    avg = statistics.fmean([float(c.get("v", 0.0)) for c in candles]) if candles else 0.0
+    zones: List[Dict[str, Any]] = []
+    for idx, candle in enumerate(candles[-20:]):
+        body = abs(float(candle.get("c", 0.0)) - float(candle.get("o", 0.0)))
+        span = max(float(candle.get("h", 0.0)) - float(candle.get("l", 0.0)), 1e-9)
+        if not span or body / span < min_ratio:
+            continue
+        if avg and candle.get("v", 0.0) < 1.2 * avg:
+            continue
+        direction = "demand" if candle.get("c", 0.0) >= candle.get("o", 0.0) else "supply"
+        zones.append({
+            "tf": tf,
+            "type": direction,
+            "open": float(min(candle.get("o", 0.0), candle.get("c", 0.0))),
+            "close": float(max(candle.get("o", 0.0), candle.get("c", 0.0))),
+            "mean": float((candle.get("o", 0.0) + candle.get("h", 0.0) + candle.get("l", 0.0) + candle.get("c", 0.0)) / 4),
+            "origin_utc": datetime.fromtimestamp(candle["t"] / 1000, tz=timezone.utc).isoformat().replace("+00:00", "Z"),
+            "status": _zone_state(candles, max(0, len(candles) - 20) + idx, direction),
+        })
+    return zones
+
+
+def _breaker_blocks(candles: Sequence[Mapping[str, float]], tf: str) -> List[Dict[str, Any]]:
+    breakers: List[Dict[str, Any]] = []
+    for idx in range(3, len(candles)):
+        window = candles[idx - 3 : idx]
+        prev_high = max(float(c.get("h", 0.0)) for c in window)
+        prev_low = min(float(c.get("l", 0.0)) for c in window)
+        open_price = float(candles[idx].get("o", 0.0))
+        close_price = float(candles[idx].get("c", 0.0))
+        direction = None
+        if close_price > prev_high and open_price < prev_high:
+            direction = "demand"
+        elif close_price < prev_low and open_price > prev_low:
+            direction = "supply"
+        if direction:
+            breakers.append({
+                "tf": tf,
+                "type": direction,
+                "open": float(min(open_price, close_price)),
+                "close": float(max(open_price, close_price)),
+                "mean": float((candles[idx].get("o", 0.0) + candles[idx].get("h", 0.0) + candles[idx].get("l", 0.0) + candles[idx].get("c", 0.0)) / 4),
+                "origin_utc": datetime.fromtimestamp(candles[idx]["t"] / 1000, tz=timezone.utc).isoformat().replace("+00:00", "Z"),
+                "status": _zone_state(candles, idx, direction),
+            })
+    return breakers
+
+
+def _swing_levels(candles: Sequence[Mapping[str, float]]) -> List[Dict[str, Any]]:
+    levels: List[Dict[str, Any]] = []
+    for idx in range(2, len(candles) - 2):
+        cur = candles[idx]
+        high = cur.get("h", 0.0)
+        low = cur.get("l", 0.0)
+        if all(high >= candles[j].get("h", 0.0) for j in range(idx - 2, idx + 3)):
+            levels.append({"type": "resistance", "price": float(high), "ts": int(cur.get("t", 0)), "valid": True})
+        if all(low <= candles[j].get("l", 0.0) for j in range(idx - 2, idx + 3)):
+            levels.append({"type": "support", "price": float(low), "ts": int(cur.get("t", 0)), "valid": True})
+    return levels
+
+
+def _equal_extremes(candles: Sequence[Mapping[str, float]], field: str, tolerance: float) -> List[Dict[str, Any]]:
+    levels: List[Dict[str, Any]] = []
+    for prev, cur in zip(candles, candles[1:]):
+        prev_val = float(prev.get(field, 0.0))
+        cur_val = float(cur.get(field, 0.0))
+        if not prev_val:
+            continue
+        if abs(cur_val - prev_val) / prev_val <= tolerance:
+            levels.append({"price": round((cur_val + prev_val) / 2, 6), "ts": int(cur.get("t", 0))})
+    return levels
+
+
+def _profile_summary(tpo_entries: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+    sessions = {"asia": [], "london": [], "ny": []}
+    daily: Dict[str, Dict[str, List[float]]] = {}
+    for entry in tpo_entries:
+        if not isinstance(entry, Mapping):
+            continue
+        date = entry.get("date")
+        session = str(entry.get("session") or "").lower() or None
+        poc, vah, val = entry.get("POC"), entry.get("VAH"), entry.get("VAL")
+        if date is not None:
+            bucket = daily.setdefault(str(date), {"poc": [], "vah": [], "val": []})
+            for key, value in (("poc", poc), ("vah", vah), ("val", val)):
+                try:
+                    bucket[key].append(float(value))
+                except (TypeError, ValueError):
+                    continue
+        if session in sessions:
+            try:
+                sessions[session].append({"date": date, "poc": float(poc), "vah": float(vah), "val": float(val)})
+            except (TypeError, ValueError):
+                continue
+    daily_levels = []
+    for date, payload in sorted(daily.items())[-3:]:
+        daily_levels.append({
+            "date": date,
+            "poc": float(statistics.fmean(payload["poc"])) if payload["poc"] else None,
+            "vah": float(statistics.fmean(payload["vah"])) if payload["vah"] else None,
+            "val": float(statistics.fmean(payload["val"])) if payload["val"] else None,
+        })
+    return {"daily": daily_levels, "sessions": sessions}
+
+
+def _context(daily_candles: Sequence[Mapping[str, float]], zones: Mapping[str, Any]) -> Dict[str, Any]:
+    bias = "neutral"
+    narrative = "No data"
+    if daily_candles:
+        last = daily_candles[-1]
+        open_price = last.get("o", 0.0)
+        close_price = last.get("c", 0.0)
+        if close_price > open_price:
+            bias = "bull"
+        elif close_price < open_price:
+            bias = "bear"
+        narrative = f"Daily candle closed {'higher' if close_price >= open_price else 'lower'} ({close_price:.2f})"
+    fresh_demand = any(zone.get("status") == "fresh" for zone in zones.get("demand", [])) if isinstance(zones, Mapping) else False
+    fresh_supply = any(zone.get("status") == "fresh" for zone in zones.get("supply", [])) if isinstance(zones, Mapping) else False
+    return {"globalBias": bias, "narrative": narrative, "openOppositeZones": fresh_demand and fresh_supply}
+
+
+async def enrich_inspection_snapshot(
+    snapshot: Mapping[str, Any],
+    *,
+    cache: MutableMapping[str, Dict[str, Any]] | None = None,
+) -> Dict[str, Any]:
+    _ = cache
+    symbol = str(snapshot.get("symbol") or "BTCUSDT").upper()
+    minute_rows = snapshot.get("ohlcv", {}).get("1m", {}).get("candles") if isinstance(snapshot.get("ohlcv"), Mapping) else []
+    if not minute_rows:
+        minute_rows = snapshot.get("candles", [])
+    minute_map = _map_minutes(minute_rows or [])
+
+    # Pull compact higher-timeframe history directly from Binance.
+    one_day, four_hour, one_hour = await asyncio.gather(
+        _fetch_recent(symbol, "1d", 3),
+        _fetch_recent(symbol, "4h", 6),
+        _fetch_recent(symbol, "1h", 72),
+    )
+
+    # Build OHLCV blocks augmented with basic supply/demand heuristics.
+    ohlcv_additions = {
+        "1d": {"symbol": symbol, "tf": "1d", "candles": one_day, **_supply_demand(one_day)},
+        "4h": {"symbol": symbol, "tf": "4h", "candles": four_hour, **_supply_demand(four_hour)},
+        "1h": {"symbol": symbol, "tf": "1h", "candles": one_hour[-24:], **_supply_demand(one_hour)},
+    }
+
+    # Derive simplified order-flow metrics from available 1m candles and footprint rows.
+    delta_rows = _delta_series(minute_map.values())
+    footprint_raw = []
+    orderflow_snapshot = snapshot.get("orderflow") if isinstance(snapshot.get("orderflow"), Mapping) else {}
+    if isinstance(orderflow_snapshot, Mapping):
+        footprint_raw = [row for row in orderflow_snapshot.get("footprint", []) if isinstance(row, Mapping)]
+    orderflow_block = {
+        "delta": delta_rows,
+        "cvd": _cvd(delta_rows),
+        "footprint": _footprint_summary(footprint_raw, minute_map),
+        "raw": footprint_raw,
+    }
+
+    enriched_zones = {
+        "mb": _block_candidates(one_hour, "1h", min_ratio=0.6) + _block_candidates(four_hour, "4h", min_ratio=0.6),
+        "bb": _breaker_blocks(one_hour, "1h"),
+        "rb": [], "pb": [],
+        "sr": _swing_levels(one_hour) + _swing_levels(four_hour),
+    }
+
+    liquidity_levels = {"eqh": _equal_extremes(one_hour, "h", 0.001), "eql": _equal_extremes(one_hour, "l", 0.001)}
+
+    data_section = snapshot.get("DATA") if isinstance(snapshot.get("DATA"), Mapping) else {}
+    tpo_entries = []
+    if isinstance(data_section, Mapping):
+        tpo_payload = data_section.get("tpo") if isinstance(data_section.get("tpo"), Mapping) else {}
+        tpo_entries = [entry for entry in tpo_payload.get("sessions", []) if isinstance(entry, Mapping)]
+    profile_levels = _profile_summary(tpo_entries)
+
+    enrichment = {
+        "status": "ok",
+        "missing_fields": [],
+        "ohlcv": ohlcv_additions,
+        "orderflow": orderflow_block,
+        "zones": enriched_zones,
+        "liquidity": liquidity_levels,
+        "profile_levels": profile_levels,
+        "risk_prefs": {"rr_min": 2.5, "risk_per_trade_pct": 1.0},
+        "context": _context(one_day, ohlcv_additions.get("1h", {})),
+    }
+    return enrichment
+
+
+def apply_enrichment_to_payload(payload: Dict[str, Any], enrichment: Mapping[str, Any]) -> None:
+    if not isinstance(payload, Mapping) or not isinstance(enrichment, Mapping):
+        return
+    data = payload.setdefault("DATA", {})
+    if not isinstance(data, dict):
+        return
+    ohlcv_block = data.setdefault("ohlcv", {})
+    if isinstance(ohlcv_block, dict):
+        for tf, block in enrichment.get("ohlcv", {}).items():
+            if isinstance(block, Mapping):
+                merged = dict(ohlcv_block.get(tf, {}))
+                merged.update(block)
+                ohlcv_block[tf] = merged
+    orderflow_block = data.setdefault("orderflow", {})
+    if isinstance(orderflow_block, dict):
+        if "cvd" in orderflow_block:
+            orderflow_block.setdefault("cvd_legacy", orderflow_block["cvd"])
+        enriched_flow = enrichment.get("orderflow")
+        if isinstance(enriched_flow, Mapping):
+            for key, value in enriched_flow.items():
+                if key == "raw":
+                    orderflow_block.setdefault("footprint_raw", value)
+                else:
+                    orderflow_block[key] = value
+    zones_block = data.setdefault("zones", {})
+    if isinstance(zones_block, dict):
+        container = zones_block.setdefault("zones", {}) if isinstance(zones_block.get("zones"), Mapping) else zones_block
+        extra = enrichment.get("zones")
+        if isinstance(container, dict) and isinstance(extra, Mapping):
+            for key, value in extra.items():
+                container[key] = value
+    data["liquidity"] = enrichment.get("liquidity")
+    data["profile_levels"] = enrichment.get("profile_levels")
+    data["risk_prefs"] = enrichment.get("risk_prefs")
+    data["context"] = enrichment.get("context")
+    data["enrichment_status"] = {
+        "status": enrichment.get("status", "ok"),
+        "missing_fields": enrichment.get("missing_fields", []),
+    }

--- a/src/services/enrichment.py
+++ b/src/services/enrichment.py
@@ -9,7 +9,8 @@ from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional,
 
 import httpx
 BINANCE_KLINES_URL = "https://api.binance.com/api/v3/klines"
-MAX_DELTA_BARS = 50; MAX_FOOTPRINT_ROWS = 10
+MAX_DELTA_BARS = 50
+MAX_FOOTPRINT_ROWS = 10
 
 
 def _parse_ts(value: Any) -> Optional[int]:
@@ -48,7 +49,7 @@ def _map_minutes(rows: Iterable[Mapping[str, Any]]) -> Dict[int, Dict[str, float
         candle = _normalise_row(row)
         if candle is not None:
             minutes[candle["t"]] = candle
-    return minutes
+    return dict(sorted(minutes.items()))
 
 
 async def _fetch_recent(symbol: str, interval: str, limit: int) -> List[Dict[str, float]]:
@@ -114,12 +115,16 @@ def _supply_demand(candles: Sequence[Mapping[str, float]]) -> Dict[str, List[Dic
 
 
 def _delta_series(candles: Iterable[Mapping[str, float]]) -> List[Dict[str, Any]]:
+    ordered = sorted((row for row in candles if isinstance(row, Mapping)), key=lambda row: row.get("t", 0))
     rows: List[Dict[str, Any]] = []
-    for candle in list(candles)[-MAX_DELTA_BARS:]:
+    for candle in ordered[-MAX_DELTA_BARS:]:
         spread = max(float(candle.get("h", 0.0)) - float(candle.get("l", 0.0)), 1e-9)
         change = float(candle.get("c", 0.0)) - float(candle.get("o", 0.0))
-        volume = float(candle.get("v", 0.0))
-        rows.append({"t": int(candle.get("t", 0)), "delta": volume * (change / spread)})
+        volume = max(float(candle.get("v", 0.0)), 0.0)
+        delta = volume * (change / spread) if volume else 0.0
+        max_delta = max(volume, 1e-9)
+        delta = max(-max_delta, min(max_delta, delta))
+        rows.append({"t": int(candle.get("t", 0)), "delta": delta})
     return rows
 
 
@@ -157,6 +162,43 @@ def _footprint_summary(footprint: Sequence[Mapping[str, Any]], minute_map: Mappi
             "absorption": bool(total_vol and imbalance > 0.55 * total_vol and abs(price_move) < 0.25 * price_span),
         })
     return summaries
+
+
+def _synthetic_footprint(minute_rows: Mapping[int, Mapping[str, float]]) -> List[Dict[str, Any]]:
+    ordered_minutes = [minute_rows[key] for key in sorted(minute_rows.keys())]
+    if not ordered_minutes:
+        return []
+    recent = ordered_minutes[-MAX_FOOTPRINT_ROWS:]
+    ranges = [max(float(row.get("h", 0.0)) - float(row.get("l", 0.0)), 1e-9) for row in recent]
+    avg_range = statistics.fmean(ranges) if ranges else 0.0
+    footprint_rows: List[Dict[str, Any]] = []
+    for candle in recent:
+        ts = int(candle.get("t", 0))
+        spread = max(float(candle.get("h", 0.0)) - float(candle.get("l", 0.0)), 1e-9)
+        volume = max(float(candle.get("v", 0.0)), 0.0)
+        change = float(candle.get("c", 0.0)) - float(candle.get("o", 0.0))
+        delta = volume * (change / spread) if volume else 0.0
+        max_delta = max(volume, 1e-9)
+        delta = max(-max_delta, min(max_delta, delta))
+        buy_volume = (volume + delta) / 2 if volume else 0.0
+        sell_volume = max(volume - buy_volume, 0.0)
+        buy_share = (buy_volume / volume * 100.0) if volume else 0.0
+        sell_share = 100.0 - buy_share if volume else 0.0
+        price_span = spread
+        absorption = bool(
+            volume
+            and abs(delta) > 0.55 * volume
+            and (abs(change) < 0.25 * (avg_range or price_span))
+        )
+        footprint_rows.append(
+            {
+                "t": ts,
+                "buy_imbalance": round(buy_share, 3),
+                "sell_imbalance": round(sell_share, 3),
+                "absorption": absorption,
+            }
+        )
+    return footprint_rows
 
 
 def _block_candidates(candles: Sequence[Mapping[str, float]], tf: str, *, min_ratio: float) -> List[Dict[str, Any]]:
@@ -297,17 +339,36 @@ async def enrich_inspection_snapshot(
     minute_map = _map_minutes(minute_rows or [])
 
     # Pull compact higher-timeframe history directly from Binance.
-    one_day, four_hour, one_hour = await asyncio.gather(
+    fetches = await asyncio.gather(
         _fetch_recent(symbol, "1d", 3),
         _fetch_recent(symbol, "4h", 6),
-        _fetch_recent(symbol, "1h", 72),
+        _fetch_recent(symbol, "1h", 24),
+        return_exceptions=True,
     )
+
+    status = "ok"
+    missing_fields: List[str] = []
+    one_day: List[Dict[str, float]] = []
+    four_hour: List[Dict[str, float]] = []
+    one_hour: List[Dict[str, float]] = []
+
+    for interval, result in zip(("1d", "4h", "1h"), fetches):
+        if isinstance(result, Exception):
+            missing_fields.append(f"ohlcv:{interval}")
+            status = "insufficient_data"
+            continue
+        if interval == "1d":
+            one_day = result
+        elif interval == "4h":
+            four_hour = result
+        else:
+            one_hour = result
 
     # Build OHLCV blocks augmented with basic supply/demand heuristics.
     ohlcv_additions = {
         "1d": {"symbol": symbol, "tf": "1d", "candles": one_day, **_supply_demand(one_day)},
         "4h": {"symbol": symbol, "tf": "4h", "candles": four_hour, **_supply_demand(four_hour)},
-        "1h": {"symbol": symbol, "tf": "1h", "candles": one_hour[-24:], **_supply_demand(one_hour)},
+        "1h": {"symbol": symbol, "tf": "1h", "candles": one_hour, **_supply_demand(one_hour)},
     }
 
     # Derive simplified order-flow metrics from available 1m candles and footprint rows.
@@ -316,12 +377,24 @@ async def enrich_inspection_snapshot(
     orderflow_snapshot = snapshot.get("orderflow") if isinstance(snapshot.get("orderflow"), Mapping) else {}
     if isinstance(orderflow_snapshot, Mapping):
         footprint_raw = [row for row in orderflow_snapshot.get("footprint", []) if isinstance(row, Mapping)]
+    footprint_summary = _footprint_summary(footprint_raw, minute_map)
+    if not footprint_summary:
+        footprint_summary = _synthetic_footprint(minute_map)
     orderflow_block = {
         "delta": delta_rows,
         "cvd": _cvd(delta_rows),
-        "footprint": _footprint_summary(footprint_raw, minute_map),
+        "footprint": footprint_summary,
         "raw": footprint_raw,
     }
+    if not delta_rows:
+        status = "insufficient_data"
+        missing_fields.append("orderflow:delta")
+    if not orderflow_block["cvd"]:
+        status = "insufficient_data"
+        missing_fields.append("orderflow:cvd")
+    if not orderflow_block["footprint"]:
+        status = "insufficient_data"
+        missing_fields.append("orderflow:footprint")
 
     enriched_zones = {
         "mb": _block_candidates(one_hour, "1h", min_ratio=0.6) + _block_candidates(four_hour, "4h", min_ratio=0.6),
@@ -340,8 +413,8 @@ async def enrich_inspection_snapshot(
     profile_levels = _profile_summary(tpo_entries)
 
     enrichment = {
-        "status": "ok",
-        "missing_fields": [],
+        "status": status,
+        "missing_fields": sorted(set(missing_fields)),
         "ohlcv": ohlcv_additions,
         "orderflow": orderflow_block,
         "zones": enriched_zones,

--- a/src/services/news.py
+++ b/src/services/news.py
@@ -1,13 +1,67 @@
 """News feed aggregator for Binance assets."""
 from __future__ import annotations
 
-import random
+import logging
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List
+from typing import Dict, List, Tuple
+
+import httpx
+
+LOGGER = logging.getLogger(__name__)
+COINGECKO_EVENTS = "https://api.coingecko.com/api/v3/events"
+_NEWS_CACHE: Dict[str, Tuple[datetime, List[Dict[str, object]]]] = {}
+
+
+def _symbol_to_keyword(symbol: str) -> str:
+    base = symbol.upper().replace("USDT", "").replace("BUSD", "")
+    mapping = {"BTC": "bitcoin", "ETH": "ethereum", "SOL": "solana"}
+    return mapping.get(base, base.lower())
+
+
+async def _fetch_coingecko_events(keyword: str, window_hours: int) -> List[Dict[str, object]]:
+    now = datetime.now(timezone.utc)
+    min_time = now - timedelta(hours=window_hours)
+    params = {"upcoming_events_only": "false", "page": "1", "type": "event"}
+    async with httpx.AsyncClient(timeout=httpx.Timeout(15.0)) as client:
+        response = await client.get(COINGECKO_EVENTS, params=params)
+        response.raise_for_status()
+        payload = response.json()
+    entries = payload.get("data", []) if isinstance(payload, dict) else []
+    events: List[Dict[str, object]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        title = str(entry.get("title") or "")
+        description = str(entry.get("description") or "")
+        if keyword.lower() not in (title + " " + description).lower():
+            continue
+        start_time = entry.get("start_date") or entry.get("start_date_detail", {}).get("date")
+        if not start_time:
+            continue
+        try:
+            event_time = datetime.fromisoformat(str(start_time))
+            if event_time.tzinfo is None:
+                event_time = event_time.replace(tzinfo=timezone.utc)
+            event_time = event_time.astimezone(timezone.utc)
+        except ValueError:
+            continue
+        if event_time < min_time:
+            continue
+        events.append(
+            {
+                "title": title,
+                "source": entry.get("screenshot") or entry.get("website"),
+                "time_utc": event_time.isoformat().replace("+00:00", "Z"),
+                "impact": (entry.get("importance") or "low").lower(),
+            }
+        )
+        if len(events) >= 10:
+            break
+    return events
 
 
 async def fetch_news(symbol: str, window_hours: int) -> List[Dict[str, object]]:
-    """Return mocked news events within the requested window."""
+    """Fetch crypto events for the requested symbol within the time window."""
 
     if window_hours <= 0:
         raise ValueError("window_hours must be positive")
@@ -15,32 +69,19 @@ async def fetch_news(symbol: str, window_hours: int) -> List[Dict[str, object]]:
     if not symbol_clean:
         raise ValueError("symbol is required")
 
+    cache_key = f"{symbol_clean}:{window_hours}"
     now = datetime.now(timezone.utc)
-    start = now - timedelta(hours=window_hours)
-    topics = [
-        "Ecosystem upgrade",
-        "Partnership announcement",
-        "Liquidity mining update",
-        "Perpetual funding adjustment",
-        "Regulatory headline",
-    ]
-    impacts = ["low", "medium", "high"]
-    tags = ["announcement", "upgrade", "listing", "macro"]
+    cached = _NEWS_CACHE.get(cache_key)
+    if cached and cached[0] > now:
+        return cached[1]
 
-    events: List[Dict[str, object]] = []
-    cursor = start
-    while cursor < now:
-        cursor += timedelta(hours=random.randint(6, 18))
-        if cursor >= now:
-            break
-        events.append(
-            {
-                "symbol": symbol_clean,
-                "time_utc": cursor.isoformat().replace("+00:00", "Z"),
-                "title": random.choice(topics),
-                "impact": random.choice(impacts),
-                "tag": random.choice(tags),
-            }
-        )
+    keyword = _symbol_to_keyword(symbol_clean)
+    try:
+        events = await _fetch_coingecko_events(keyword, window_hours)
+    except Exception as exc:  # pragma: no cover - external dependency guard
+        LOGGER.warning("Falling back to empty news feed: %s", exc)
+        events = []
 
+    expiry = now + timedelta(hours=24)
+    _NEWS_CACHE[cache_key] = (expiry, events)
     return events

--- a/src/services/ohlcv.py
+++ b/src/services/ohlcv.py
@@ -10,12 +10,13 @@ from typing import Dict, Iterable, List, Mapping, MutableMapping
 import httpx
 
 BINANCE_SPOT_KLINES = "https://api.binance.com/api/v3/klines"
-SUPPORTED_TIMEFRAMES: tuple[str, ...] = ("1m", "3m", "5m", "15m", "4h", "1d")
+SUPPORTED_TIMEFRAMES: tuple[str, ...] = ("1m", "3m", "5m", "15m", "1h", "4h", "1d")
 TIMEFRAME_TO_MINUTES: Dict[str, int] = {
     "1m": 1,
     "3m": 3,
     "5m": 5,
     "15m": 15,
+    "1h": 60,
     "4h": 240,
     "1d": 1_440,
 }

--- a/tests/test_check_all_datas.py
+++ b/tests/test_check_all_datas.py
@@ -9,6 +9,7 @@ from src.api.app import app
 import src.services.check_all_datas as check_all_datas
 import src.services.inspection as inspection
 from src.services import presets
+from src.services.collection_state import reset_state, set_last_collection_time
 
 UTC = timezone.utc
 
@@ -226,6 +227,36 @@ def test_check_all_returns_structured_payload(client: TestClient) -> None:
 
     assert body["risk_prefs"] == {"rr_min": pytest.approx(2.5), "risk_per_trade_pct": pytest.approx(1.0)}
     assert body["context"] == {"globalBias": "neutral", "narrative": "", "openOppositeZones": False}
+
+
+def test_topup_limits_window_to_last_collection(client: TestClient) -> None:
+    reset_state()
+    base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+    payload = _build_snapshot_payload(base, count=60 * 6)
+
+    create_response = client.post("/inspection/snapshot", json=payload)
+    assert create_response.status_code == 200
+    snapshot_id = create_response.json()["snapshot_id"]
+
+    last_collection_dt = base + timedelta(hours=5, minutes=55)
+    set_last_collection_time(last_collection_dt)
+
+    try:
+        response = client.get(
+            "/inspection/check-all",
+            params={"snapshot": snapshot_id, "mode": "topup"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+
+        for zone_key in ("fvg", "ob", "mb", "bb", "rb", "pb", "sr"):
+            zone_entries = body["zones"].get(zone_key, [])
+            assert zone_entries, f"expected informational entry for {zone_key}"
+            message_entry = zone_entries[0]
+            assert "message" in message_entry
+            assert "выбранный период" in message_entry["message"].lower()
+    finally:
+        reset_state()
 
 
 def test_multi_timeframe_ohlcv_alignment(client: TestClient) -> None:

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -1,0 +1,97 @@
+"""Tests for inspection enrichment helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services import enrichment
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_enrichment_adds_daily_and_orderflow(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_ts = 1_700_000_000_000
+    minute_candles = []
+    for idx in range(60):
+        open_price = 100.0 + idx * 0.1
+        close_price = open_price + (0.2 if idx % 2 == 0 else -0.15)
+        high_price = max(open_price, close_price) + 0.1
+        low_price = min(open_price, close_price) - 0.1
+        minute_candles.append(
+            {
+                "t": base_ts + idx * 60_000,
+                "o": open_price,
+                "h": high_price,
+                "l": low_price,
+                "c": close_price,
+                "v": 20.0 + idx,
+            }
+        )
+
+    async def _fake_fetch_recent(symbol: str, interval: str, limit: int):  # type: ignore[override]
+        if interval == "1d":
+            return [
+                {
+                    "t": base_ts - (3 - idx) * 86_400_000,
+                    "o": 100.0 + idx,
+                    "h": 101.0 + idx,
+                    "l": 99.0 + idx,
+                    "c": 100.5 + idx,
+                    "v": 1000.0 + idx * 10,
+                }
+                for idx in range(3)
+            ]
+        if interval == "4h":
+            return [
+                {
+                    "t": base_ts - (6 - idx) * 14_400_000,
+                    "o": 100.0 + idx * 0.3,
+                    "h": 100.6 + idx * 0.3,
+                    "l": 99.4 + idx * 0.3,
+                    "c": 100.2 + idx * 0.3,
+                    "v": 400.0 + idx * 5,
+                }
+                for idx in range(6)
+            ]
+        if interval == "1h":
+            return [
+                {
+                    "t": base_ts - (limit - idx) * 3_600_000,
+                    "o": 100.0 + idx * 0.2,
+                    "h": 100.4 + idx * 0.2,
+                    "l": 99.6 + idx * 0.2,
+                    "c": 100.1 + idx * 0.2,
+                    "v": 200.0 + idx * 3,
+                }
+                for idx in range(limit)
+            ]
+        raise AssertionError(f"unexpected interval {interval}")
+
+    monkeypatch.setattr(enrichment, "_fetch_recent", _fake_fetch_recent)
+
+    snapshot = {
+        "symbol": "BTCUSDT",
+        "tf": "1m",
+        "ohlcv": {"1m": {"candles": minute_candles}},
+    }
+
+    payload = await enrichment.enrich_inspection_snapshot(snapshot)
+
+    ohlcv_block = payload["ohlcv"]["1d"]
+    assert len(ohlcv_block["candles"]) == 3
+    assert ohlcv_block["demand"] or ohlcv_block["supply"]
+
+    delta_series = payload["orderflow"]["delta"]
+    assert 0 < len(delta_series) <= enrichment.MAX_DELTA_BARS
+
+    cvd_series = payload["orderflow"]["cvd"]
+    assert len(cvd_series) == len(delta_series)
+
+    footprint = payload["orderflow"]["footprint"]
+    assert footprint, "synthetic footprint should be populated"
+
+    assert payload["status"] == "ok"


### PR DESCRIPTION
## Summary
- add inspection enrichment pipeline to compute multi-timeframe OHLCV supply/demand, order-flow delta/CVD, zone/liq/profile/risk context, and merge it into /inspection responses
- integrate cached CoinGecko events for the news feed and expose the new enrichment utilities through the service layer
- extend OHLCV support to include the 1h timeframe required by the enriched analytics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd27e655d0832496fce3af9978186c