### PR TITLE
Revamp check-all last price handling and diagnostics

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -52,6 +52,16 @@
     valSeries: null,
     inspectProgressTimer: null,
     lastSnapshotId: null,
+    shared: {
+      pending: new Map(),
+      resetPending: false,
+      lastUpdateMs: null,
+      flushTimer: null,
+      inFlight: false,
+      dirty: false,
+      lastFlushMs: 0,
+      flushPromise: null,
+    },
   };
 
   const marketStore =
@@ -179,25 +189,174 @@
     };
   }
 
-  function persistSharedCandles({ bars = null, reset = false, lastUpdateMs = null } = {}) {
-    if (!SharedCandles || typeof SharedCandles.merge !== "function") return;
-    const payload = Array.isArray(bars) && bars.length ? bars : state.candles;
-    if (!Array.isArray(payload) || !payload.length) return;
-    const intervalMs = intervalToMs(state.interval);
-    const effectiveUpdate = Number.isFinite(lastUpdateMs) ? Number(lastUpdateMs) : state.lastUpdateMs;
-    try {
-      SharedCandles.merge(state.symbol, state.interval, payload, {
-        intervalMs,
-        lastUpdateMs: effectiveUpdate,
-        maxBars: 2000,
-        reset,
-      });
-    } catch (error) {
-      console.warn("SharedCandles merge failed", error);
+  function toSharedBar(bar) {
+    if (!bar) return null;
+    const time = Number(bar.time ?? bar.t ?? 0);
+    const open = Number(bar.open ?? bar.o);
+    const high = Number(bar.high ?? bar.h);
+    const low = Number(bar.low ?? bar.l);
+    const close = Number(bar.close ?? bar.c);
+    if (
+      !Number.isFinite(time) ||
+      !Number.isFinite(open) ||
+      !Number.isFinite(high) ||
+      !Number.isFinite(low) ||
+      !Number.isFinite(close)
+    ) {
+      return null;
+    }
+    return { time, open, high, low, close };
+  }
+
+  function persistSharedCandles({ bars = null, reset = false, lastUpdateMs = null, immediate = false } = {}) {
+    const shared = state.shared;
+    if (reset) {
+      shared.pending = new Map();
+      shared.resetPending = true;
+    }
+    const entries = Array.isArray(bars) ? bars : [];
+    for (const bar of entries) {
+      const sharedBar = toSharedBar(bar);
+      if (!sharedBar) continue;
+      shared.pending.set(sharedBar.time, sharedBar);
+    }
+    if (Number.isFinite(lastUpdateMs)) {
+      shared.lastUpdateMs = Number(lastUpdateMs);
+    }
+    if (shared.pending.size || shared.resetPending) {
+      scheduleSharedFlush({ immediate: immediate || reset });
     }
   }
 
-  function mergeCandles(bars, { reset = false, lastUpdateMs = null } = {}) {
+  function scheduleSharedFlush({ immediate = false, waitMs = null, force = false } = {}) {
+    const shared = state.shared;
+    const now = Date.now();
+    const sinceLast = now - (shared.lastFlushMs || 0);
+    let delay;
+    if (Number.isFinite(waitMs)) {
+      delay = Math.max(0, waitMs);
+    } else {
+      const baseDelay = Math.max(0, 1000 - sinceLast);
+      delay = immediate ? baseDelay : Math.max(250, baseDelay);
+    }
+    if (delay === 0 && shared.flushTimer) {
+      clearTimeout(shared.flushTimer);
+      shared.flushTimer = null;
+    }
+    if (shared.flushTimer) {
+      return;
+    }
+    shared.flushTimer = setTimeout(() => {
+      shared.flushTimer = null;
+      flushSharedCandles({ force }).catch((error) => {
+        console.warn("SharedCandles flush failed", error);
+      });
+    }, delay);
+  }
+
+  function wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+  }
+
+  async function flushSharedCandles({ force = false } = {}) {
+    const shared = state.shared;
+    if (!shared.pending.size && !shared.resetPending) {
+      return;
+    }
+    if (shared.inFlight) {
+      shared.dirty = true;
+      return shared.flushPromise || Promise.resolve();
+    }
+
+    const execute = async () => {
+      const now = Date.now();
+      const sinceLast = now - (shared.lastFlushMs || 0);
+      if (!force && sinceLast < 1000) {
+        scheduleSharedFlush({ waitMs: 1000 - sinceLast });
+        return;
+      }
+      if (force && sinceLast < 1000) {
+        await wait(1000 - sinceLast);
+      }
+      if (shared.flushTimer) {
+        clearTimeout(shared.flushTimer);
+        shared.flushTimer = null;
+      }
+      const pendingEntries = Array.from(shared.pending.values());
+      const reset = shared.resetPending;
+      const lastUpdateMs = Number.isFinite(shared.lastUpdateMs) ? Number(shared.lastUpdateMs) : Date.now();
+      shared.pending = new Map();
+      shared.resetPending = false;
+      shared.inFlight = true;
+      shared.dirty = false;
+
+      const payload = pendingEntries
+        .map((bar) => ({ ...bar }))
+        .sort((a, b) => Number(a.time) - Number(b.time));
+
+      if (SharedCandles && typeof SharedCandles.merge === "function") {
+        try {
+          SharedCandles.merge(state.symbol, state.interval, payload, {
+            intervalMs: intervalToMs(state.interval),
+            lastUpdateMs,
+            maxBars: 2000,
+            reset,
+            syncRemote: false,
+          });
+        } catch (error) {
+          console.warn("SharedCandles local merge failed", error);
+        }
+      }
+
+      try {
+        const response = await fetch("/shared-candles", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          cache: "no-store",
+          body: JSON.stringify({
+            symbol: state.symbol,
+            interval: state.interval,
+            candles: payload,
+            reset,
+            intervalMs: intervalToMs(state.interval),
+            lastUpdateMs,
+            maxBars: 2000,
+          }),
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        shared.lastFlushMs = Date.now();
+        shared.lastUpdateMs = lastUpdateMs;
+      } catch (error) {
+        console.warn("SharedCandles remote sync failed", error);
+        const buffer = shared.pending;
+        if (reset) {
+          buffer.clear();
+        }
+        for (const bar of payload) {
+          buffer.set(Number(bar.time), { ...bar });
+        }
+        shared.resetPending = reset || shared.resetPending;
+        shared.dirty = true;
+      } finally {
+        shared.inFlight = false;
+        if (!shared.dirty) {
+          shared.lastFlushMs = shared.lastFlushMs || Date.now();
+        }
+        if (shared.dirty || shared.pending.size) {
+          scheduleSharedFlush();
+        }
+      }
+    };
+
+    shared.flushPromise = execute().finally(() => {
+      shared.flushPromise = null;
+    });
+    return shared.flushPromise;
+  }
+
+  function mergeCandles(bars, { reset = false, lastUpdateMs = null, immediate = false } = {}) {
     if (reset) state.candles = [];
     if (!Array.isArray(bars) || !bars.length) return false;
     const index = new Map();
@@ -205,6 +364,7 @@
       index.set(Number(bar.time), idx);
     });
     let changed = false;
+    const delta = new Map();
     bars.forEach((bar) => {
       if (!bar) return;
       const time = Number(bar.time);
@@ -212,10 +372,12 @@
       if (index.has(time)) {
         state.candles[index.get(time)] = bar;
         changed = true;
+        delta.set(time, bar);
       } else {
         index.set(time, state.candles.length);
         state.candles.push(bar);
         changed = true;
+        delta.set(time, bar);
       }
     });
     if (changed) {
@@ -225,7 +387,8 @@
       }
       const effectiveUpdate = Number.isFinite(lastUpdateMs) ? Number(lastUpdateMs) : Date.now();
       state.lastUpdateMs = effectiveUpdate;
-      persistSharedCandles({ reset, lastUpdateMs: effectiveUpdate });
+      const changedBars = Array.from(delta.values());
+      persistSharedCandles({ bars: changedBars, reset, lastUpdateMs: effectiveUpdate, immediate });
     }
     return changed;
   }
@@ -241,7 +404,7 @@
           const bars = stored.candles.map((bar) => normaliseBar(bar)).filter(Boolean);
           if (bars.length) {
             const lastUpdate = Number(stored.lastUpdateMs) || Number(stored.updatedAt) || Date.now();
-            mergeCandles(bars, { reset: true, lastUpdateMs: lastUpdate });
+          mergeCandles(bars, { reset: true, lastUpdateMs: lastUpdate, immediate: true });
             restored = true;
             applied = true;
           }
@@ -260,6 +423,7 @@
           mergeCandles(remote.candles.map((bar) => normaliseBar(bar)).filter(Boolean), {
             reset: shouldReset,
             lastUpdateMs: lastUpdate,
+            immediate: shouldReset,
           });
           restored = true;
           applied = true;
@@ -317,7 +481,7 @@
 
     if (event.type === "snapshot") {
       const bars = Array.isArray(event.candles) ? event.candles : [];
-      const changed = mergeCandles(bars, { reset: true, lastUpdateMs: now });
+      const changed = mergeCandles(bars, { reset: true, lastUpdateMs: now, immediate: true });
       if (changed) {
         applyCandles();
         focusOnLastCandle({ preserveSpan: false });
@@ -326,14 +490,14 @@
       notifyStatus("История загружена", "success");
     } else if (event.type === "update") {
       const payload = event.candle ? [event.candle] : [];
-      const changed = mergeCandles(payload, { reset: false, lastUpdateMs: now });
+      const changed = mergeCandles(payload, { reset: false, lastUpdateMs: now, immediate: Boolean(event.isFinal) });
       if (changed) {
         applyCandles(event.candle);
         refreshGapWatcherContext();
       }
     } else if (event.type === "poll") {
       const bars = Array.isArray(event.candles) ? event.candles : [];
-      if (mergeCandles(bars, { reset: false, lastUpdateMs: now })) {
+      if (mergeCandles(bars, { reset: false, lastUpdateMs: now, immediate: false })) {
         applyCandles();
       }
     }
@@ -490,7 +654,7 @@
         Number(gap.endMs) + intervalMs,
         Math.min(1000, Math.max(approxBars, 50))
       );
-      const changed = mergeCandles(bars, { lastUpdateMs: Date.now() });
+      const changed = mergeCandles(bars, { lastUpdateMs: Date.now(), immediate: true });
       if (changed) {
         applyCandles();
         if (state.gapWatcher && typeof state.gapWatcher.notifyData === "function") {
@@ -571,6 +735,17 @@
     setActiveSymbolButton(normalizedSymbol);
     fetchPreset(normalizedSymbol);
     initChart();
+    if (state.shared.flushTimer) {
+      clearTimeout(state.shared.flushTimer);
+      state.shared.flushTimer = null;
+    }
+    state.shared.pending = new Map();
+    state.shared.resetPending = false;
+    state.shared.lastUpdateMs = null;
+    state.shared.inFlight = false;
+    state.shared.dirty = false;
+    state.shared.lastFlushMs = 0;
+    state.shared.flushPromise = null;
     const restored = await restoreFromSharedStore(normalizedSymbol, normalizedInterval);
     if (restored) {
       applyCandles();
@@ -681,6 +856,7 @@
   }
 
   async function submitInspectionSnapshot() {
+    await flushSharedCandles({ force: true });
     const snapshot = buildInspectionSnapshot();
     toggleInspectionProgress(true);
     if (inspectionBtn) inspectionBtn.disabled = true;

--- a/public/app.js
+++ b/public/app.js
@@ -5,6 +5,7 @@
   const BinanceCandles = window.BinanceCandles;
   const ChartGapWatcher = window.ChartGapWatcher;
   const SharedCandles = window.SharedCandles;
+  const MarketDataStore = window.MarketDataStore || null;
 
   if (!LightweightCharts || !BinanceCandles) {
     console.error("Chart dependencies are missing");
@@ -44,9 +45,6 @@
     chart: null,
     candleSeries: null,
     priceLine: null,
-    ws: null,
-    reconnectTimer: null,
-    reconnectAttempts: 0,
     gapWatcher: null,
     lastUpdateMs: null,
     pocSeries: null,
@@ -55,6 +53,15 @@
     inspectProgressTimer: null,
     lastSnapshotId: null,
   };
+
+  const marketStore =
+    MarketDataStore &&
+    new MarketDataStore({
+      symbol: state.symbol,
+      interval: state.interval,
+      pollIntervalMs: 1500,
+      historyLimit: 1500,
+    });
 
   function setActiveSymbolButton(symbol) {
     if (!symbolButtons.length) return;
@@ -128,7 +135,7 @@
   async function fetchVersion() {
     if (!versionEl) return;
     try {
-      const response = await fetch("/version");
+      const response = await fetch("/version", { cache: "no-store" });
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const data = await response.json();
       versionEl.textContent = typeof data.version === "string" ? data.version : "—";
@@ -141,7 +148,7 @@
   async function fetchPreset(symbol) {
     if (!presetBadge) return;
     try {
-      const response = await fetch(`/presets/${encodeURIComponent(symbol)}`);
+      const response = await fetch(`/presets/${encodeURIComponent(symbol)}`, { cache: "no-store" });
       if (!response.ok) throw new Error("Preset request failed");
       const data = await response.json();
       const preset = data && data.preset ? data.preset : null;
@@ -268,6 +275,79 @@
     return restored;
   }
 
+
+  function refreshGapWatcherContext() {
+    if (!state.gapWatcher || typeof state.gapWatcher.updateContext !== "function") return;
+    state.gapWatcher.updateContext({
+      symbol: state.symbol,
+      interval: state.interval,
+      intervalMs: intervalToMs(state.interval),
+      getCandles: () => state.candles,
+      requestGap: handleGapRequest,
+      resetRequestedKeys: false,
+    });
+    if (typeof state.gapWatcher.notifyData === "function") {
+      state.gapWatcher.notifyData();
+    }
+  }
+
+  function handleStoreEvent(event) {
+    if (!event) return;
+    const eventSymbol = (event.symbol || "").toUpperCase();
+    if (eventSymbol && eventSymbol !== state.symbol) return;
+    if (event.interval && event.interval !== state.interval) return;
+
+    if (event.type === "status") {
+      if (event.status === "connected") {
+        notifyStatus("Подключено к потоку Binance", "info");
+      } else if (event.status === "closed") {
+        notifyStatus("Соединение закрыто, активирован пуллинг", "warning");
+      } else if (event.status === "error") {
+        notifyStatus("Ошибка потока, переподключение...", "warning");
+      }
+      return;
+    }
+
+    if (event.type === "error") {
+      notifyStatus("Ошибка загрузки данных Binance", "error");
+      return;
+    }
+
+    const now = Date.now();
+
+    if (event.type === "snapshot") {
+      const bars = Array.isArray(event.candles) ? event.candles : [];
+      const changed = mergeCandles(bars, { reset: true, lastUpdateMs: now });
+      if (changed) {
+        applyCandles();
+        focusOnLastCandle({ preserveSpan: false });
+        refreshGapWatcherContext();
+      }
+      notifyStatus("История загружена", "success");
+    } else if (event.type === "update") {
+      const payload = event.candle ? [event.candle] : [];
+      const changed = mergeCandles(payload, { reset: false, lastUpdateMs: now });
+      if (changed) {
+        applyCandles(event.candle);
+        refreshGapWatcherContext();
+      }
+    } else if (event.type === "poll") {
+      const bars = Array.isArray(event.candles) ? event.candles : [];
+      if (mergeCandles(bars, { reset: false, lastUpdateMs: now })) {
+        applyCandles();
+      }
+    }
+
+    if (event.meta && event.meta.last_price != null) {
+      updateInfo(event.candle || marketStore?.getLastCandle() || null);
+    }
+  }
+
+  if (marketStore) {
+    marketStore.subscribe(handleStoreEvent);
+    marketStore.start();
+  }
+
   function updateInfo(lastBar) {
     const bar = lastBar || state.candles[state.candles.length - 1];
     if (!bar) {
@@ -374,89 +454,6 @@
     timeScale.scrollToRealTime();
   }
 
-  function detachWs() {
-    if (state.ws) {
-      state.ws.onopen = null;
-      state.ws.onmessage = null;
-      state.ws.onclose = null;
-      state.ws.onerror = null;
-      state.ws.close(1000);
-    }
-    state.ws = null;
-    if (state.reconnectTimer) {
-      clearTimeout(state.reconnectTimer);
-      state.reconnectTimer = null;
-    }
-  }
-
-  function scheduleReconnect() {
-    if (state.reconnectTimer) return;
-    const delay = Math.min(30_000, 1_000 * Math.pow(2, state.reconnectAttempts));
-    state.reconnectTimer = setTimeout(() => {
-      state.reconnectTimer = null;
-      connectWs();
-    }, delay);
-  }
-
-  function handleWsMessage(event) {
-    if (!state.candleSeries) return;
-    try {
-      const payload = JSON.parse(event.data);
-      const bar = BinanceCandles.barFromWs(payload);
-      const normalised = normaliseBar(bar);
-      if (!normalised) return;
-      const last = state.candles[state.candles.length - 1];
-      const nowMs = Date.now();
-      if (last && Number(last.time) === Number(normalised.time)) {
-        state.candles[state.candles.length - 1] = normalised;
-        state.candleSeries.update(normalised);
-        state.lastUpdateMs = nowMs;
-        persistSharedCandles({ bars: [normalised], lastUpdateMs: nowMs });
-      } else if (!last || Number(normalised.time) > Number(last.time)) {
-        state.candles.push(normalised);
-        state.candleSeries.update(normalised);
-        state.lastUpdateMs = nowMs;
-        persistSharedCandles({ bars: [normalised], lastUpdateMs: nowMs });
-      } else {
-        mergeCandles([normalised], { lastUpdateMs: nowMs });
-        state.candleSeries.setData(state.candles);
-      }
-      updatePriceLine(normalised);
-      updateInfo(normalised);
-      if (state.gapWatcher && typeof state.gapWatcher.notifyData === "function") {
-        state.gapWatcher.notifyData();
-      }
-    } catch (error) {
-      console.error("Failed to parse ws message", error);
-    }
-  }
-
-  function connectWs() {
-    detachWs();
-    const symbol = state.symbol.toLowerCase();
-    const interval = state.interval;
-    const url = `wss://fstream.binance.com/ws/${symbol}@kline_${interval}`;
-    const ws = new WebSocket(url);
-    state.ws = ws;
-    ws.onopen = () => {
-      state.reconnectAttempts = 0;
-      notifyStatus("Подключено к потоку Binance", "info");
-    };
-    ws.onmessage = handleWsMessage;
-    ws.onerror = (event) => {
-      console.error("WebSocket error", event);
-      notifyStatus("Ошибка WebSocket, переподключение...", "warning");
-      ws.close();
-    };
-    ws.onclose = () => {
-      if (state.ws === ws) {
-        state.reconnectAttempts += 1;
-        notifyStatus("Соединение закрыто, переподключаемся...", "warning");
-        scheduleReconnect();
-      }
-    };
-  }
-
   async function fetchHistory(symbol, interval, limit = 500) {
     const rows = await BinanceCandles.fetchHistory(symbol, interval, limit);
     return rows.map((bar) => normaliseBar(bar)).filter(Boolean);
@@ -473,7 +470,7 @@
       url.searchParams.set("endTime", Math.floor(endMs));
     }
     url.searchParams.set("limit", String(Math.max(1, Math.min(limit, 1500))));
-    const resp = await fetch(url.toString());
+    const resp = await fetch(url.toString(), { cache: "no-store" });
     if (!resp.ok) {
       throw new Error(`Failed to fetch gap candles: ${resp.status}`);
     }
@@ -565,7 +562,6 @@
   }
 
   async function loadSymbol(symbol, interval) {
-    detachWs();
     notifyStatus("Загружаем историю...", "info");
     const normalizedSymbol = symbol.trim().toUpperCase();
     const normalizedInterval = interval.trim();
@@ -576,30 +572,16 @@
     fetchPreset(normalizedSymbol);
     initChart();
     const restored = await restoreFromSharedStore(normalizedSymbol, normalizedInterval);
-    if (restored && state.gapWatcher && typeof state.gapWatcher.notifyData === "function") {
-      state.gapWatcher.notifyData();
-    }
-    try {
-      const history = await fetchHistory(normalizedSymbol, normalizedInterval, 1000);
-      mergeCandles(history, { reset: true, lastUpdateMs: Date.now() });
+    if (restored) {
       applyCandles();
       focusOnLastCandle({ preserveSpan: false });
-      if (state.gapWatcher && typeof state.gapWatcher.updateContext === "function") {
-        state.gapWatcher.updateContext({
-          symbol: state.symbol,
-          interval: state.interval,
-          intervalMs: intervalToMs(state.interval),
-          getCandles: () => state.candles,
-          requestGap: handleGapRequest,
-          resetRequestedKeys: true,
-        });
-        state.gapWatcher.notifyData();
-      }
-      notifyStatus("История загружена", "success");
-      connectWs();
-    } catch (error) {
-      console.error("Failed to load history", error);
-      notifyStatus("Не удалось загрузить данные Binance", "error");
+      refreshGapWatcherContext();
+    }
+    if (marketStore) {
+      marketStore.setSymbol(normalizedSymbol, normalizedInterval);
+      marketStore.restart();
+    } else {
+      notifyStatus("Лайв-хранилище недоступно", "error");
     }
   }
 
@@ -706,6 +688,7 @@
       const response = await fetch("/inspection/snapshot", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        cache: "no-store",
         body: JSON.stringify(snapshot),
       });
       if (!response.ok) {
@@ -730,7 +713,10 @@
     try {
       const url = new URL("/inspection", window.location.origin);
       url.searchParams.set("snapshot", snapshotId);
-      const response = await fetch(url.toString(), { headers: { accept: "application/json" } });
+      const response = await fetch(url.toString(), {
+        headers: { accept: "application/json" },
+        cache: "no-store",
+      });
       if (!response.ok) throw new Error("Inspection payload unavailable");
       const payload = await response.json();
       const data = payload?.DATA || {};
@@ -762,6 +748,7 @@
       const response = await fetch("/inspection/analyze", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        cache: "no-store",
         body: JSON.stringify({ snapshot_id: state.lastSnapshotId, analysis_type: type }),
       });
       if (!response.ok) {
@@ -796,7 +783,7 @@
       const url = new URL("/profile", window.location.origin);
       url.searchParams.set("snapshot", state.lastSnapshotId);
       url.searchParams.set("tf", state.interval);
-      const response = await fetch(url.toString());
+      const response = await fetch(url.toString(), { cache: "no-store" });
       if (!response.ok) throw new Error("Profile export failed");
       const data = await response.json();
       const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
@@ -860,8 +847,8 @@
   }
 
   document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "visible" && !state.ws) {
-      connectWs();
+    if (document.visibilityState === "visible" && marketStore) {
+      marketStore.restart();
     }
   });
 

--- a/public/binanceCandles.js
+++ b/public/binanceCandles.js
@@ -127,7 +127,7 @@
       `&interval=${encodeURIComponent(interval)}` +
       `&limit=${encodeURIComponent(cappedLimit)}`;
 
-    const resp = await fetch(url);
+    const resp = await fetch(url, { cache: "no-store" });
     if (!resp.ok) {
       throw new Error(`klines ${resp.status}`);
     }

--- a/public/market-data-store.js
+++ b/public/market-data-store.js
@@ -1,0 +1,390 @@
+(function (global) {
+  "use strict";
+
+  const BinanceCandles = global.BinanceCandles;
+
+  if (!BinanceCandles) {
+    console.error("BinanceCandles dependency is missing");
+    return;
+  }
+
+  const DEFAULT_HISTORY_LIMIT = 600;
+  const DEFAULT_POLL_INTERVAL_MS = 2000;
+  const WS_HOST = "wss://fstream.binance.com";
+
+  function clampLimit(limit) {
+    const numeric = Number(limit);
+    if (!Number.isFinite(numeric)) return DEFAULT_HISTORY_LIMIT;
+    return Math.max(50, Math.min(1500, Math.floor(numeric)));
+  }
+
+  function normaliseSymbol(symbol) {
+    return (symbol || "").trim().toUpperCase();
+  }
+
+  function normaliseInterval(interval) {
+    return (interval || "1m").trim();
+  }
+
+  function normaliseBar(bar) {
+    if (!bar) return null;
+    const open = Number(bar.open ?? bar.o);
+    const high = Number(bar.high ?? bar.h);
+    const low = Number(bar.low ?? bar.l);
+    const close = Number(bar.close ?? bar.c);
+    const time = Number(bar.time ?? bar.t ?? 0);
+    if (
+      !Number.isFinite(time) ||
+      !Number.isFinite(open) ||
+      !Number.isFinite(high) ||
+      !Number.isFinite(low) ||
+      !Number.isFinite(close)
+    ) {
+      return null;
+    }
+    return {
+      time,
+      open,
+      high,
+      low,
+      close,
+      ts_ms_utc: time * 1000,
+    };
+  }
+
+  function inferTickSize(price) {
+    if (!Number.isFinite(price) || price <= 0) {
+      return 0.5;
+    }
+    const absPrice = Math.abs(price);
+    if (absPrice >= 1000) return 0.5;
+    if (absPrice >= 100) return 0.1;
+    if (absPrice >= 10) return 0.01;
+    if (absPrice >= 1) return 0.001;
+    if (absPrice >= 0.1) return 0.0001;
+    return 0.00001;
+  }
+
+  function computeMeta({ candles, interval, lastStreamPrice, lastStreamTs }) {
+    const last = candles.length ? candles[candles.length - 1] : null;
+    if (!last) {
+      return {
+        interval,
+        last_price: null,
+        last_ts_ms: null,
+        last_tf: interval,
+        age_sec: null,
+        stale: true,
+        mismatch: false,
+      };
+    }
+    const now = Date.now();
+    const ageSec = Math.max(0, Math.round((now - last.ts_ms_utc) / 1000));
+    const stale = ageSec > 300;
+    let mismatch = false;
+    if (Number.isFinite(lastStreamPrice) && Number.isFinite(lastStreamTs)) {
+      const diff = Math.abs(lastStreamPrice - last.close);
+      const tick = inferTickSize(last.close);
+      const lagMs = now - Number(lastStreamTs);
+      mismatch = diff > tick + 1e-9 && lagMs > 2000;
+    }
+    return {
+      interval,
+      last_price: last.close,
+      last_ts_ms: last.ts_ms_utc,
+      last_tf: interval,
+      age_sec: ageSec,
+      stale,
+      mismatch,
+    };
+  }
+
+  class MarketDataStore {
+    constructor(options = {}) {
+      this.symbol = normaliseSymbol(options.symbol) || "BTCUSDT";
+      this.interval = normaliseInterval(options.interval || "1m");
+      this.historyLimit = clampLimit(options.historyLimit || DEFAULT_HISTORY_LIMIT);
+      this.pollIntervalMs = Math.max(1000, Number(options.pollIntervalMs) || DEFAULT_POLL_INTERVAL_MS);
+      this.listeners = new Set();
+      this.candles = [];
+      this.ws = null;
+      this.wsTimer = null;
+      this.pollTimer = null;
+      this.loadingHistory = false;
+      this.connected = false;
+      this.lastStreamPrice = null;
+      this.lastStreamTs = null;
+      this._initialised = false;
+      this._pendingHistory = null;
+    }
+
+    subscribe(handler) {
+      if (typeof handler !== "function") return () => {};
+      this.listeners.add(handler);
+      return () => {
+        this.listeners.delete(handler);
+      };
+    }
+
+    _emit(event) {
+      for (const handler of Array.from(this.listeners)) {
+        try {
+          handler(event, this);
+        } catch (error) {
+          console.warn("MarketDataStore listener failed", error);
+        }
+      }
+    }
+
+    start() {
+      if (this._initialised) return;
+      this._initialised = true;
+      this._loadHistory().catch((error) => {
+        console.error("MarketDataStore history failed", error);
+        this._emit({ type: "error", error });
+      });
+      this._ensureRealtime();
+      this._ensurePolling();
+    }
+
+    stop() {
+      this._initialised = false;
+      this._teardownWs();
+      if (this.pollTimer) {
+        clearInterval(this.pollTimer);
+        this.pollTimer = null;
+      }
+    }
+
+    async _loadHistory(force = false) {
+      if (this.loadingHistory && !force) {
+        return this._pendingHistory;
+      }
+      this.loadingHistory = true;
+      const loadPromise = BinanceCandles.fetchHistory(this.symbol, this.interval, this.historyLimit)
+        .then((rows) => rows.map((bar) => normaliseBar(bar)).filter(Boolean))
+        .then((bars) => {
+          this.candles = bars;
+          this.loadingHistory = false;
+          const meta = computeMeta({
+            candles: this.candles,
+            interval: this.interval,
+            lastStreamPrice: this.lastStreamPrice,
+            lastStreamTs: this.lastStreamTs,
+          });
+          this._emit({ type: "snapshot", symbol: this.symbol, interval: this.interval, candles: this.candles.slice(), meta });
+          return bars;
+        })
+        .catch((error) => {
+          this.loadingHistory = false;
+          throw error;
+        });
+      this._pendingHistory = loadPromise;
+      return loadPromise;
+    }
+
+    _ensureRealtime() {
+      this._teardownWs();
+      const urlSymbol = this.symbol.toLowerCase();
+      const streamUrl = `${WS_HOST}/ws/${urlSymbol}@kline_${this.interval}`;
+      try {
+        const ws = new WebSocket(streamUrl);
+        this.ws = ws;
+        ws.onopen = () => {
+          this.connected = true;
+          this._emit({ type: "status", status: "connected", symbol: this.symbol, interval: this.interval });
+        };
+        ws.onerror = (event) => {
+          console.error("MarketDataStore websocket error", event);
+          this._emit({ type: "status", status: "error", symbol: this.symbol, interval: this.interval });
+          ws.close();
+        };
+        ws.onclose = () => {
+          if (this.ws === ws) {
+            this.connected = false;
+            this._emit({ type: "status", status: "closed", symbol: this.symbol, interval: this.interval });
+            this._scheduleReconnect();
+          }
+        };
+        ws.onmessage = (event) => {
+          try {
+            const payload = JSON.parse(event.data);
+            const bar = BinanceCandles.barFromWs(payload);
+            const normalised = normaliseBar(bar);
+            if (!normalised) return;
+            this.lastStreamPrice = normalised.close;
+            this.lastStreamTs = Date.now();
+            this._mergeBars([normalised]);
+            const meta = computeMeta({
+              candles: this.candles,
+              interval: this.interval,
+              lastStreamPrice: this.lastStreamPrice,
+              lastStreamTs: this.lastStreamTs,
+            });
+            this._emit({
+              type: "update",
+              symbol: this.symbol,
+              interval: this.interval,
+              candle: normalised,
+              candles: this.candles.slice(-10),
+              meta,
+            });
+          } catch (error) {
+            console.error("MarketDataStore message parse failed", error);
+          }
+        };
+      } catch (error) {
+        console.error("MarketDataStore websocket setup failed", error);
+        this._scheduleReconnect();
+      }
+    }
+
+    _scheduleReconnect() {
+      if (this.wsTimer) return;
+      this.wsTimer = setTimeout(() => {
+        this.wsTimer = null;
+        if (!this._initialised) return;
+        this._ensureRealtime();
+      }, 3000);
+    }
+
+    _teardownWs() {
+      if (this.ws) {
+        try {
+          this.ws.onopen = null;
+          this.ws.onclose = null;
+          this.ws.onerror = null;
+          this.ws.onmessage = null;
+          this.ws.close(1000);
+        } catch (error) {
+          console.warn("MarketDataStore ws teardown failed", error);
+        }
+      }
+      this.ws = null;
+      if (this.wsTimer) {
+        clearTimeout(this.wsTimer);
+        this.wsTimer = null;
+      }
+    }
+
+    _ensurePolling() {
+      if (this.pollTimer) {
+        clearInterval(this.pollTimer);
+      }
+      this.pollTimer = setInterval(() => {
+        this._pollLatest().catch((error) => {
+          console.warn("MarketDataStore poll failed", error);
+        });
+      }, this.pollIntervalMs);
+    }
+
+    async _pollLatest() {
+      const last = this.candles.length ? this.candles[this.candles.length - 1] : null;
+      const startTime = last ? last.ts_ms_utc - 5 * 60 * 1000 : undefined;
+      const params = new URLSearchParams();
+      params.set("symbol", this.symbol);
+      params.set("interval", this.interval);
+      if (Number.isFinite(startTime)) {
+        params.set("startTime", String(Math.max(0, Math.floor(startTime))));
+      }
+      params.set("limit", String(Math.min(150, Math.max(10, Math.floor(this.historyLimit / 4)))));
+      const url = `https://fapi.binance.com/fapi/v1/klines?${params.toString()}`;
+      const response = await fetch(url, { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(`poll klines ${response.status}`);
+      }
+      const rows = await response.json();
+      const bars = BinanceCandles.transformKlines(rows).map((bar) => normaliseBar(bar)).filter(Boolean);
+      if (!bars.length) return;
+      this._mergeBars(bars);
+      const meta = computeMeta({
+        candles: this.candles,
+        interval: this.interval,
+        lastStreamPrice: this.lastStreamPrice,
+        lastStreamTs: this.lastStreamTs,
+      });
+      this._emit({ type: "poll", symbol: this.symbol, interval: this.interval, candles: bars, meta });
+    }
+
+    _mergeBars(bars) {
+      if (!Array.isArray(bars) || !bars.length) return;
+      const index = new Map();
+      this.candles.forEach((bar, idx) => {
+        index.set(Number(bar.time), idx);
+      });
+      let changed = false;
+      for (const bar of bars) {
+        if (!bar) continue;
+        const key = Number(bar.time);
+        if (!Number.isFinite(key)) continue;
+        if (index.has(key)) {
+          const targetIdx = index.get(key);
+          const existing = this.candles[targetIdx];
+          if (
+            existing.open !== bar.open ||
+            existing.high !== bar.high ||
+            existing.low !== bar.low ||
+            existing.close !== bar.close
+          ) {
+            this.candles[targetIdx] = bar;
+            changed = true;
+          }
+        } else {
+          index.set(key, this.candles.length);
+          this.candles.push(bar);
+          changed = true;
+        }
+      }
+      if (changed) {
+        this.candles.sort((a, b) => Number(a.time) - Number(b.time));
+        if (this.candles.length > this.historyLimit) {
+          this.candles = this.candles.slice(this.candles.length - this.historyLimit);
+        }
+      }
+    }
+
+    setSymbol(symbol, interval) {
+      const nextSymbol = normaliseSymbol(symbol) || this.symbol;
+      const nextInterval = normaliseInterval(interval) || this.interval;
+      const symbolChanged = nextSymbol !== this.symbol;
+      const intervalChanged = nextInterval !== this.interval;
+      if (!symbolChanged && !intervalChanged) {
+        return;
+      }
+      this.symbol = nextSymbol;
+      this.interval = nextInterval;
+      this.candles = [];
+      this.lastStreamPrice = null;
+      this.lastStreamTs = null;
+      this._emit({ type: "status", status: "restarting", symbol: this.symbol, interval: this.interval });
+      this._loadHistory(true).catch((error) => {
+        console.error("MarketDataStore reload failed", error);
+      });
+      this._ensureRealtime();
+      this._ensurePolling();
+    }
+
+    restart() {
+      this._loadHistory(true).catch((error) => {
+        console.error("MarketDataStore restart failed", error);
+      });
+      this._ensureRealtime();
+      this._ensurePolling();
+    }
+
+    getMeta() {
+      return computeMeta({
+        candles: this.candles,
+        interval: this.interval,
+        lastStreamPrice: this.lastStreamPrice,
+        lastStreamTs: this.lastStreamTs,
+      });
+    }
+
+    getLastCandle() {
+      return this.candles.length ? this.candles[this.candles.length - 1] : null;
+    }
+  }
+
+  global.MarketDataStore = MarketDataStore;
+})(typeof window !== "undefined" ? window : this);

--- a/public/market-data-store.js
+++ b/public/market-data-store.js
@@ -10,6 +10,9 @@
 
   const DEFAULT_HISTORY_LIMIT = 600;
   const DEFAULT_POLL_INTERVAL_MS = 2000;
+  const HEARTBEAT_THRESHOLD_MS = 2000;
+  const STREAM_SILENCE_THRESHOLD_MS = 5000;
+  const MISSED_HEARTBEAT_LIMIT = 3;
   const WS_HOST = "wss://fstream.binance.com";
 
   function clampLimit(limit) {
@@ -65,7 +68,13 @@
     return 0.00001;
   }
 
-  function computeMeta({ candles, interval, lastStreamPrice, lastStreamTs }) {
+  function computeMeta({
+    candles,
+    interval,
+    lastStreamPrice,
+    lastStreamTs,
+    lastPriceSource,
+  }) {
     const last = candles.length ? candles[candles.length - 1] : null;
     if (!last) {
       return {
@@ -76,6 +85,7 @@
         age_sec: null,
         stale: true,
         mismatch: false,
+        last_price_source: null,
       };
     }
     const now = Date.now();
@@ -96,6 +106,7 @@
       age_sec: ageSec,
       stale,
       mismatch,
+      last_price_source: lastPriceSource || (Number.isFinite(lastStreamPrice) ? "stream" : "ohlcv"),
     };
   }
 
@@ -110,12 +121,17 @@
       this.ws = null;
       this.wsTimer = null;
       this.pollTimer = null;
+      this.healthTimer = null;
       this.loadingHistory = false;
       this.connected = false;
       this.lastStreamPrice = null;
       this.lastStreamTs = null;
+      this.lastPriceSource = null;
       this._initialised = false;
       this._pendingHistory = null;
+      this._missedHeartbeats = 0;
+      this._pollingActive = false;
+      this._pollInFlight = false;
     }
 
     subscribe(handler) {
@@ -144,16 +160,15 @@
         this._emit({ type: "error", error });
       });
       this._ensureRealtime();
-      this._ensurePolling();
+      this._startHealthMonitor();
     }
 
     stop() {
       this._initialised = false;
       this._teardownWs();
-      if (this.pollTimer) {
-        clearInterval(this.pollTimer);
-        this.pollTimer = null;
-      }
+      this._stopHealthMonitor();
+      this._pollingActive = false;
+      this._stopPolling();
     }
 
     async _loadHistory(force = false) {
@@ -165,12 +180,14 @@
         .then((rows) => rows.map((bar) => normaliseBar(bar)).filter(Boolean))
         .then((bars) => {
           this.candles = bars;
+          this.lastPriceSource = bars.length ? "ohlcv" : null;
           this.loadingHistory = false;
           const meta = computeMeta({
             candles: this.candles,
             interval: this.interval,
             lastStreamPrice: this.lastStreamPrice,
             lastStreamTs: this.lastStreamTs,
+            lastPriceSource: this.lastPriceSource,
           });
           this._emit({ type: "snapshot", symbol: this.symbol, interval: this.interval, candles: this.candles.slice(), meta });
           return bars;
@@ -204,6 +221,7 @@
             this.connected = false;
             this._emit({ type: "status", status: "closed", symbol: this.symbol, interval: this.interval });
             this._scheduleReconnect();
+            this._setPollingActive(true);
           }
         };
         ws.onmessage = (event) => {
@@ -212,14 +230,27 @@
             const bar = BinanceCandles.barFromWs(payload);
             const normalised = normaliseBar(bar);
             if (!normalised) return;
+            const kline = payload?.k || {};
+            const closeTime = Number(kline.T);
+            const eventTime = Number(payload?.E);
+            if (Number.isFinite(closeTime)) {
+              normalised.ts_ms_utc = closeTime;
+            } else if (Number.isFinite(eventTime)) {
+              normalised.ts_ms_utc = eventTime;
+            }
             this.lastStreamPrice = normalised.close;
-            this.lastStreamTs = Date.now();
-            this._mergeBars([normalised]);
+            this.lastStreamTs = Number.isFinite(eventTime) ? Number(eventTime) : Date.now();
+            const isFinal = Boolean(kline.x);
+            this._mergeBars([normalised], { source: "stream", isFinal });
+            if (isFinal) {
+              this._emit({ type: "heartbeat", symbol: this.symbol, interval: this.interval });
+            }
             const meta = computeMeta({
               candles: this.candles,
               interval: this.interval,
               lastStreamPrice: this.lastStreamPrice,
               lastStreamTs: this.lastStreamTs,
+              lastPriceSource: this.lastPriceSource,
             });
             this._emit({
               type: "update",
@@ -227,8 +258,10 @@
               interval: this.interval,
               candle: normalised,
               candles: this.candles.slice(-10),
+              isFinal,
               meta,
             });
+            this._handleHeartbeat();
           } catch (error) {
             console.error("MarketDataStore message parse failed", error);
           }
@@ -267,52 +300,130 @@
       }
     }
 
-    _ensurePolling() {
-      if (this.pollTimer) {
-        clearInterval(this.pollTimer);
+    _startHealthMonitor() {
+      this._stopHealthMonitor();
+      this.healthTimer = setInterval(() => {
+        this._checkStreamHealth();
+      }, 1000);
+    }
+
+    _stopHealthMonitor() {
+      if (this.healthTimer) {
+        clearInterval(this.healthTimer);
+        this.healthTimer = null;
       }
-      this.pollTimer = setInterval(() => {
-        this._pollLatest().catch((error) => {
-          console.warn("MarketDataStore poll failed", error);
-        });
+    }
+
+    _handleHeartbeat() {
+      this._missedHeartbeats = 0;
+      this._setPollingActive(false);
+    }
+
+    _checkStreamHealth() {
+      const now = Date.now();
+      const delta = this.lastStreamTs ? now - this.lastStreamTs : Infinity;
+      const websocketActive = this.ws && this.ws.readyState === WebSocket.OPEN;
+      if (!websocketActive) {
+        this._setPollingActive(true);
+        return;
+      }
+      if (delta <= HEARTBEAT_THRESHOLD_MS) {
+        this._missedHeartbeats = 0;
+        this._setPollingActive(false);
+        return;
+      }
+      this._missedHeartbeats += 1;
+      const exceededSilence = delta > STREAM_SILENCE_THRESHOLD_MS;
+      if (exceededSilence || this._missedHeartbeats >= MISSED_HEARTBEAT_LIMIT) {
+        this._setPollingActive(true);
+      }
+    }
+
+    _setPollingActive(active) {
+      if (active) {
+        if (this._pollingActive) return;
+        this._pollingActive = true;
+        this._schedulePoll();
+      } else {
+        if (!this._pollingActive) return;
+        this._pollingActive = false;
+        this._stopPolling();
+      }
+    }
+
+    _schedulePoll() {
+      if (!this._pollingActive) return;
+      if (this.pollTimer) return;
+      this.pollTimer = setTimeout(() => {
+        this.pollTimer = null;
+        if (!this._pollingActive) return;
+        this._pollLatest()
+          .catch((error) => {
+            console.warn("MarketDataStore poll failed", error);
+          })
+          .finally(() => {
+            if (this._pollingActive) {
+              this._schedulePoll();
+            }
+          });
       }, this.pollIntervalMs);
     }
 
-    async _pollLatest() {
-      const last = this.candles.length ? this.candles[this.candles.length - 1] : null;
-      const startTime = last ? last.ts_ms_utc - 5 * 60 * 1000 : undefined;
-      const params = new URLSearchParams();
-      params.set("symbol", this.symbol);
-      params.set("interval", this.interval);
-      if (Number.isFinite(startTime)) {
-        params.set("startTime", String(Math.max(0, Math.floor(startTime))));
+    _stopPolling() {
+      if (this.pollTimer) {
+        clearTimeout(this.pollTimer);
+        this.pollTimer = null;
       }
-      params.set("limit", String(Math.min(150, Math.max(10, Math.floor(this.historyLimit / 4)))));
-      const url = `https://fapi.binance.com/fapi/v1/klines?${params.toString()}`;
-      const response = await fetch(url, { cache: "no-store" });
-      if (!response.ok) {
-        throw new Error(`poll klines ${response.status}`);
-      }
-      const rows = await response.json();
-      const bars = BinanceCandles.transformKlines(rows).map((bar) => normaliseBar(bar)).filter(Boolean);
-      if (!bars.length) return;
-      this._mergeBars(bars);
-      const meta = computeMeta({
-        candles: this.candles,
-        interval: this.interval,
-        lastStreamPrice: this.lastStreamPrice,
-        lastStreamTs: this.lastStreamTs,
-      });
-      this._emit({ type: "poll", symbol: this.symbol, interval: this.interval, candles: bars, meta });
+      this._pollInFlight = false;
     }
 
-    _mergeBars(bars) {
+    async _pollLatest() {
+      if (this._pollInFlight) {
+        return;
+      }
+      this._pollInFlight = true;
+      try {
+        const last = this.candles.length ? this.candles[this.candles.length - 1] : null;
+        const startTime = last ? last.ts_ms_utc - 5 * 60 * 1000 : undefined;
+        const params = new URLSearchParams();
+        params.set("symbol", this.symbol);
+        params.set("interval", this.interval);
+        if (Number.isFinite(startTime)) {
+          params.set("startTime", String(Math.max(0, Math.floor(startTime))));
+        }
+        params.set("limit", String(Math.min(150, Math.max(10, Math.floor(this.historyLimit / 4)))));
+        const url = `https://fapi.binance.com/fapi/v1/klines?${params.toString()}`;
+        const response = await fetch(url, { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(`poll klines ${response.status}`);
+        }
+        const rows = await response.json();
+        const bars = BinanceCandles.transformKlines(rows).map((bar) => normaliseBar(bar)).filter(Boolean);
+        if (!bars.length) {
+          return;
+        }
+        this._mergeBars(bars, { source: "ohlcv" });
+        const meta = computeMeta({
+          candles: this.candles,
+          interval: this.interval,
+          lastStreamPrice: this.lastStreamPrice,
+          lastStreamTs: this.lastStreamTs,
+          lastPriceSource: this.lastPriceSource,
+        });
+        this._emit({ type: "poll", symbol: this.symbol, interval: this.interval, candles: bars, meta });
+      } finally {
+        this._pollInFlight = false;
+      }
+    }
+
+    _mergeBars(bars, options = {}) {
       if (!Array.isArray(bars) || !bars.length) return;
       const index = new Map();
       this.candles.forEach((bar, idx) => {
         index.set(Number(bar.time), idx);
       });
       let changed = false;
+      const touchedTimes = new Set();
       for (const bar of bars) {
         if (!bar) continue;
         const key = Number(bar.time);
@@ -328,17 +439,23 @@
           ) {
             this.candles[targetIdx] = bar;
             changed = true;
+            touchedTimes.add(key);
           }
         } else {
           index.set(key, this.candles.length);
           this.candles.push(bar);
           changed = true;
+          touchedTimes.add(key);
         }
       }
       if (changed) {
         this.candles.sort((a, b) => Number(a.time) - Number(b.time));
         if (this.candles.length > this.historyLimit) {
           this.candles = this.candles.slice(this.candles.length - this.historyLimit);
+        }
+        const lastCandle = this.candles[this.candles.length - 1];
+        if (lastCandle && touchedTimes.has(Number(lastCandle.time))) {
+          this.lastPriceSource = options?.source || this.lastPriceSource || "ohlcv";
         }
       }
     }
@@ -356,12 +473,16 @@
       this.candles = [];
       this.lastStreamPrice = null;
       this.lastStreamTs = null;
+      this.lastPriceSource = null;
+      this._missedHeartbeats = 0;
+      this._pollingActive = false;
+      this._stopPolling();
       this._emit({ type: "status", status: "restarting", symbol: this.symbol, interval: this.interval });
       this._loadHistory(true).catch((error) => {
         console.error("MarketDataStore reload failed", error);
       });
       this._ensureRealtime();
-      this._ensurePolling();
+      this._startHealthMonitor();
     }
 
     restart() {
@@ -369,7 +490,9 @@
         console.error("MarketDataStore restart failed", error);
       });
       this._ensureRealtime();
-      this._ensurePolling();
+      this._pollingActive = false;
+      this._stopPolling();
+      this._startHealthMonitor();
     }
 
     getMeta() {
@@ -378,6 +501,7 @@
         interval: this.interval,
         lastStreamPrice: this.lastStreamPrice,
         lastStreamTs: this.lastStreamTs,
+        lastPriceSource: this.lastPriceSource,
       });
     }
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -50,8 +50,9 @@ from ..services.news import fetch_news
 from ..services.ohlcv import build_multi_tf_ohlcv, fetch_ohlcv as fetch_ohlcv_enhanced
 from ..services.orderflow import calculate_cvd, fetch_footprint
 from ..services.tpo import calculate_session_tpo, calculate_tpo
-from ..version import APP_VERSION
 from ..meta import Meta
+from ..static_version import STATIC_VERSION
+from ..version import APP_VERSION
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -326,6 +327,17 @@ app.add_middleware(
 
 if PUBLIC_DIR.is_dir():
     app.mount("/public", StaticFiles(directory=PUBLIC_DIR), name="public")
+
+
+@app.middleware("http")
+async def add_no_store_header(request: Request, call_next):
+    """Disable caching for dynamic API responses."""
+
+    response = await call_next(request)
+    path = request.url.path or ""
+    if not path.startswith("/public/"):
+        response.headers["Cache-Control"] = "no-store"
+    return response
 
 
 @app.on_event("startup")
@@ -1359,6 +1371,6 @@ async def index() -> HTMLResponse:
         html = TEMPLATES_DIR.joinpath("index.html").read_text(encoding="utf-8")
     except FileNotFoundError as exc:  # pragma: no cover - deployment guard
         raise HTTPException(status_code=500, detail="Index template is missing") from exc
-    return HTMLResponse(content=html)
+    return HTMLResponse(content=html.replace("__STATIC_VERSION__", STATIC_VERSION))
 
 

--- a/src/services/check_all_datas.py
+++ b/src/services/check_all_datas.py
@@ -206,14 +206,29 @@ def _resolve_last_price(
     frames: Mapping[str, Sequence[Mapping[str, Any]]],
     *,
     now: datetime,
-) -> Tuple[float | None, str | None, str | None, int | None, str | None]:
-    """Return last price metadata using the most granular available timeframe."""
+    stream_price: float | None = None,
+    stream_ts: int | None = None,
+    tick_size: float | None = None,
+) -> Tuple[
+    float | None,
+    str | None,
+    str | None,
+    int | None,
+    str | None,
+    str,
+    Dict[str, Any],
+]:
+    """Return last price metadata using the most granular available timeframe.
+
+    The function prefers a live stream tick when present, falling back to the
+    most granular OHLCV close otherwise. It also emits diagnostics when the
+    stream price diverges from OHLCV beyond one tick while being delayed.
+    """
 
     priority = ("1m", "3m", "5m", "15m", "1h", "4h", "1d")
-    selected_tf: str | None = None
-    last_price: float | None = None
-    last_iso: str | None = None
-    last_ts: int | None = None
+    candle_tf: str | None = None
+    candle_price: float | None = None
+    candle_ts: int | None = None
 
     for tf in priority:
         candles = frames.get(tf)
@@ -227,11 +242,27 @@ def _resolve_last_price(
         price = _safe_float(last_candle.get("c"))
         if ts is None or price is None:
             continue
-        selected_tf = tf
-        last_price = price
-        last_ts = ts
-        last_iso = _isoformat_utc(ts)
+        candle_tf = tf
+        candle_price = price
+        candle_ts = ts
         break
+
+    diagnostics: Dict[str, Any] = {}
+    price_source = "ohlcv"
+
+    last_price: float | None = candle_price
+    last_ts: int | None = candle_ts
+    last_tf: str | None = candle_tf
+
+    if stream_price is not None and stream_ts is not None:
+        price_source = "stream"
+        last_price = stream_price
+        last_ts = stream_ts
+        last_tf = "stream"
+        diagnostics["stream_ts"] = stream_ts
+        diagnostics["stream_price"] = stream_price
+
+    last_iso: str | None = _isoformat_utc(last_ts) if last_ts is not None else None
 
     insufficient_reason: str | None = None
     snapshot_age_sec: int | None = None
@@ -242,9 +273,58 @@ def _resolve_last_price(
         if snapshot_age_sec > 5 * 60:
             insufficient_reason = f"stale_snapshot_{snapshot_age_sec}"
     else:
-        insufficient_reason = "missing_ohlcv_last_price"
+        insufficient_reason = "missing_live_last_price"
 
-    return last_price, last_iso, selected_tf, snapshot_age_sec, insufficient_reason
+    if candle_price is None or candle_ts is None:
+        diagnostics["ohlcv_missing"] = True
+    else:
+        diagnostics["ohlcv_price"] = candle_price
+        diagnostics["ohlcv_ts"] = candle_ts
+        diagnostics["ohlcv_tf"] = candle_tf
+
+    if price_source == "stream" and candle_price is not None and candle_ts is not None:
+        tick = float(tick_size) if tick_size else None
+        if tick is not None and tick > 0:
+            diff = abs(stream_price - candle_price)
+            interval_ms = TIMEFRAME_TO_MS.get(candle_tf or "1m", 60_000)
+            candle_close_ms = candle_ts + interval_ms
+            lag_ms = abs(stream_ts - candle_close_ms)
+            diagnostics["stream_vs_candle_diff"] = diff
+            diagnostics["stream_vs_candle_lag_ms"] = lag_ms
+            if diff > tick and lag_ms > 2000:
+                diagnostics["mismatch"] = True
+                LOGGER.warning(
+                    "Stream vs OHLCV mismatch detected",
+                    extra={
+                        "stream_price": stream_price,
+                        "ohlcv_price": candle_price,
+                        "tick_size": tick,
+                        "lag_ms": lag_ms,
+                        "diff": diff,
+                        "ohlcv_tf": candle_tf,
+                    },
+                )
+
+    LOGGER.info(
+        "Resolved last price for inspection snapshot",
+        extra={
+            "source": price_source,
+            "tf": last_tf,
+            "ts": last_ts,
+            "age_sec": snapshot_age_sec,
+            "insufficient_reason": insufficient_reason,
+        },
+    )
+
+    return (
+        last_price,
+        last_iso,
+        last_tf,
+        snapshot_age_sec,
+        insufficient_reason,
+        price_source,
+        diagnostics,
+    )
 
 
 def _build_expected_times(start_ms: int, end_ms: int, interval_ms: int) -> List[int]:
@@ -428,6 +508,33 @@ def _aggregate_from_minutes(
         "c": bucket[-1]["c"],
         "v": sum(item["v"] for item in bucket),
     }
+
+
+def _normalise_stream_point(candidate: Mapping[str, Any] | None) -> Tuple[float | None, int | None]:
+    if not isinstance(candidate, Mapping):
+        return None, None
+
+    price: float | None = None
+    for key in ("price", "last_price", "p", "value", "close"):
+        price = _safe_float(candidate.get(key))
+        if price is not None:
+            break
+
+    ts_raw: int | None = None
+    for key in ("ts", "timestamp", "time", "t", "ts_ms", "event_time"):
+        value = candidate.get(key)
+        if value is None:
+            continue
+        ts_raw = _safe_int(value)
+        if ts_raw is not None:
+            if ts_raw < 10_000_000_000:
+                ts_raw *= 1000
+            break
+
+    if price is None or ts_raw is None:
+        return None, None
+
+    return price, ts_raw
 
 
 def _coerce_float(value: Any) -> float:
@@ -1930,6 +2037,30 @@ def build_check_all_datas(
 
     symbol = str(snapshot.get("symbol") or snapshot.get("pair") or "UNKNOWN").upper()
     raw_meta = snapshot.get("meta") if isinstance(snapshot.get("meta"), Mapping) else None
+
+    stream_price: float | None = None
+    stream_ts: int | None = None
+    stream_candidates: List[Mapping[str, Any]] = []
+
+    for key in ("stream", "live", "live_price", "live_tick"):
+        candidate = snapshot.get(key)
+        if isinstance(candidate, Mapping):
+            stream_candidates.append(candidate)
+
+    if isinstance(raw_meta, Mapping):
+        for key in ("stream", "live", "live_price", "ticker"):
+            candidate = raw_meta.get(key)
+            if isinstance(candidate, Mapping):
+                stream_candidates.append(candidate)
+
+    for candidate in stream_candidates:
+        price, ts = _normalise_stream_point(candidate)
+        if price is None or ts is None:
+            continue
+        stream_price = price
+        stream_ts = ts
+        break
+
     profile_config = resolve_profile_config(symbol, raw_meta)
     sessions = list(VWAP_TPO_SESSIONS)
     profile_tpo: List[Dict[str, Any]] = []
@@ -2131,46 +2262,6 @@ def build_check_all_datas(
 
     frames["1m"] = [minute_index_all[ts] for ts in sorted(minute_index_all)]
     minute_candles = frames["1m"]
-
-    last_price_value, last_iso_ts, last_tf, snapshot_age_sec, insufficient_reason = _resolve_last_price(
-        frames,
-        now=now_dt,
-    )
-
-    if last_tf is not None and last_iso_ts is not None and last_price_value is not None:
-        LOGGER.info(
-            "Resolved last price from OHLCV",
-            extra={
-                "snapshot_tf": last_tf,
-                "snapshot_ts": last_iso_ts,
-                "snapshot_price": last_price_value,
-            },
-        )
-
-    if snapshot_age_sec is not None:
-        LOGGER.info("Snapshot age evaluated", extra={"snapshot_age_sec": snapshot_age_sec})
-
-    analysis_entry_price = None
-    analysis_block = snapshot.get("analysis") if isinstance(snapshot.get("analysis"), Mapping) else None
-    if isinstance(analysis_block, Mapping):
-        trade_block = analysis_block.get("trade")
-        if isinstance(trade_block, Mapping):
-            analysis_entry_price = _safe_float(trade_block.get("entry_price"))
-
-    if (
-        analysis_entry_price is not None
-        and last_price_value is not None
-        and not math.isclose(analysis_entry_price, last_price_value, rel_tol=1e-9, abs_tol=1e-6)
-    ):
-        LOGGER.warning(
-            "Analysis entry price differs from resolved last price",
-            extra={
-                "analysis_entry_price": analysis_entry_price,
-                "last_price": last_price_value,
-                "last_tf": last_tf,
-                "last_ts_utc": last_iso_ts,
-            },
-        )
 
     zones_window_hours = max(1, hours_window)
     if not strict_window:
@@ -2557,9 +2648,50 @@ def build_check_all_datas(
         },
     )
 
+    (
+        last_price_value,
+        last_iso_ts,
+        last_tf,
+        snapshot_age_sec,
+        insufficient_reason,
+        last_price_source,
+        last_price_diag,
+    ) = _resolve_last_price(
+        frames,
+        now=now_dt,
+        stream_price=stream_price,
+        stream_ts=stream_ts,
+        tick_size=tick_size_numeric,
+    )
+
+    if snapshot_age_sec is not None:
+        LOGGER.info("Snapshot age evaluated", extra={"snapshot_age_sec": snapshot_age_sec})
+
     if tick_size_numeric and isinstance(tick_size_numeric, (int, float)):
         zone_cfg.tick_size = float(tick_size_numeric)
     zones_diag["tick_size"] = zone_cfg.tick_size
+
+    analysis_entry_price = None
+    analysis_block = snapshot.get("analysis") if isinstance(snapshot.get("analysis"), Mapping) else None
+    if isinstance(analysis_block, Mapping):
+        trade_block = analysis_block.get("trade")
+        if isinstance(trade_block, Mapping):
+            analysis_entry_price = _safe_float(trade_block.get("entry_price"))
+
+    if (
+        analysis_entry_price is not None
+        and last_price_value is not None
+        and not math.isclose(analysis_entry_price, last_price_value, rel_tol=1e-9, abs_tol=1e-6)
+    ):
+        LOGGER.warning(
+            "Analysis entry price differs from resolved last price",
+            extra={
+                "analysis_entry_price": analysis_entry_price,
+                "last_price": last_price_value,
+                "last_tf": last_tf,
+                "last_ts_utc": last_iso_ts,
+            },
+        )
 
     if zone_frames_full:
         try:
@@ -3263,11 +3395,17 @@ def build_check_all_datas(
         "last_price": last_price_value,
         "last_ts_utc": last_iso_ts,
         "last_tf": last_tf,
+        "last_price_source": last_price_source,
     }
     if snapshot_age_sec is not None:
         meta_block["snapshot_age_sec"] = snapshot_age_sec
     if insufficient_reason:
         meta_block["insufficient_reason"] = insufficient_reason
+    meta_block["stale"] = bool(
+        isinstance(insufficient_reason, str) and insufficient_reason.startswith("stale_snapshot")
+    )
+    if last_price_diag.get("mismatch"):
+        meta_block["stream_vs_ohlcv_mismatch"] = True
 
     final_payload = {
         "meta": meta_block,

--- a/src/services/check_all_datas.py
+++ b/src/services/check_all_datas.py
@@ -6,7 +6,7 @@ import math
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone, time as dtime
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple, Set
 
 import httpx
 
@@ -23,6 +23,7 @@ from .profile import build_profile_package
 from .smc import SMCConfig, detect_smc_blocks
 from .zones import Config as ZonesConfig, detect_zones
 UTC = timezone.utc
+LOGGER = logging.getLogger(__name__)
 MS_IN_HOUR = 3_600_000
 MS_IN_DAY = 86_400_000
 VALID_HOUR_WINDOWS = {1, 2, 3, 4}
@@ -199,6 +200,51 @@ def _deduplicate_sorted(
 
     ordered_times = sorted(seen)
     return [seen[ts] for ts in ordered_times]
+
+
+def _resolve_last_price(
+    frames: Mapping[str, Sequence[Mapping[str, Any]]],
+    *,
+    now: datetime,
+) -> Tuple[float | None, str | None, str | None, int | None, str | None]:
+    """Return last price metadata using the most granular available timeframe."""
+
+    priority = ("1m", "3m", "5m", "15m", "1h", "4h", "1d")
+    selected_tf: str | None = None
+    last_price: float | None = None
+    last_iso: str | None = None
+    last_ts: int | None = None
+
+    for tf in priority:
+        candles = frames.get(tf)
+        if not candles:
+            continue
+        deduped = _deduplicate_sorted(candles)
+        if not deduped:
+            continue
+        last_candle = deduped[-1]
+        ts = _safe_int(last_candle.get("t"))
+        price = _safe_float(last_candle.get("c"))
+        if ts is None or price is None:
+            continue
+        selected_tf = tf
+        last_price = price
+        last_ts = ts
+        last_iso = _isoformat_utc(ts)
+        break
+
+    insufficient_reason: str | None = None
+    snapshot_age_sec: int | None = None
+
+    if last_ts is not None:
+        now_ms = int(now.timestamp() * 1000)
+        snapshot_age_sec = max(0, (now_ms - last_ts) // 1000)
+        if snapshot_age_sec > 5 * 60:
+            insufficient_reason = f"stale_snapshot_{snapshot_age_sec}"
+    else:
+        insufficient_reason = "missing_ohlcv_last_price"
+
+    return last_price, last_iso, selected_tf, snapshot_age_sec, insufficient_reason
 
 
 def _build_expected_times(start_ms: int, end_ms: int, interval_ms: int) -> List[int]:
@@ -1894,6 +1940,7 @@ def build_check_all_datas(
         "symbol": symbol,
         "zones": {
             "fvg": [],
+            "fvl": [],
             "ob": [],
             "mb": [],
             "bb": [],
@@ -1964,6 +2011,10 @@ def build_check_all_datas(
             now_dt = now_utc.replace(tzinfo=UTC)
         else:
             now_dt = now_utc.astimezone(UTC)
+    else:
+        now_dt = datetime.now(UTC)
+
+    if now_utc is not None:
         now_ms = int(now_dt.timestamp() * 1000)
         window_end_ms = _align_to_interval(now_ms, MINUTE_INTERVAL_MS) - MINUTE_INTERVAL_MS
     else:
@@ -2080,6 +2131,46 @@ def build_check_all_datas(
 
     frames["1m"] = [minute_index_all[ts] for ts in sorted(minute_index_all)]
     minute_candles = frames["1m"]
+
+    last_price_value, last_iso_ts, last_tf, snapshot_age_sec, insufficient_reason = _resolve_last_price(
+        frames,
+        now=now_dt,
+    )
+
+    if last_tf is not None and last_iso_ts is not None and last_price_value is not None:
+        LOGGER.info(
+            "Resolved last price from OHLCV",
+            extra={
+                "snapshot_tf": last_tf,
+                "snapshot_ts": last_iso_ts,
+                "snapshot_price": last_price_value,
+            },
+        )
+
+    if snapshot_age_sec is not None:
+        LOGGER.info("Snapshot age evaluated", extra={"snapshot_age_sec": snapshot_age_sec})
+
+    analysis_entry_price = None
+    analysis_block = snapshot.get("analysis") if isinstance(snapshot.get("analysis"), Mapping) else None
+    if isinstance(analysis_block, Mapping):
+        trade_block = analysis_block.get("trade")
+        if isinstance(trade_block, Mapping):
+            analysis_entry_price = _safe_float(trade_block.get("entry_price"))
+
+    if (
+        analysis_entry_price is not None
+        and last_price_value is not None
+        and not math.isclose(analysis_entry_price, last_price_value, rel_tol=1e-9, abs_tol=1e-6)
+    ):
+        LOGGER.warning(
+            "Analysis entry price differs from resolved last price",
+            extra={
+                "analysis_entry_price": analysis_entry_price,
+                "last_price": last_price_value,
+                "last_tf": last_tf,
+                "last_ts_utc": last_iso_ts,
+            },
+        )
 
     zones_window_hours = max(1, hours_window)
     if not strict_window:
@@ -2490,6 +2581,7 @@ def build_check_all_datas(
             detected_zones = {
                 "zones": {
                     "fvg": [],
+                    "fvl": [],
                     "ob": [],
                     "mb": [],
                     "bb": [],
@@ -2573,6 +2665,7 @@ def build_check_all_datas(
                 zones_diag["detection"] = detection_diag
     zone_type_timeframes = {
         "fvg": ("15m", "1h", "4h"),
+        "fvl": ("15m", "1h", "4h"),
         "ob": ("15m", "1h", "4h"),
         "mb": ("1h", "4h"),
         "bb": ("1h", "4h"),
@@ -2584,6 +2677,7 @@ def build_check_all_datas(
     if isinstance(zones_container, MutableMapping):
         timestamp_filters = {
             "fvg": "created_utc",
+            "fvl": "created_utc",
             "ob": "origin_utc",
             "mb": "origin_utc",
             "bb": "origin_utc",
@@ -3008,7 +3102,7 @@ def build_check_all_datas(
         orderflow_public[tf] = {"per_bar": per_bar}
 
     zones_container = detected_zones.get("zones") if isinstance(detected_zones, Mapping) else None
-    zone_keys = ("fvg", "ob", "mb", "bb", "rb", "pb", "sr", "profile_levels")
+    zone_keys = ("fvg", "fvl", "ob", "mb", "bb", "rb", "pb", "sr", "profile_levels")
     zones_public: Dict[str, List[Dict[str, Any]]] = {key: [] for key in zone_keys}
     if isinstance(zones_container, Mapping):
         for key in zone_keys:
@@ -3078,7 +3172,7 @@ def build_check_all_datas(
         "openOppositeZones": bool(raw_open_opposite) if isinstance(raw_open_opposite, bool) else False,
     }
 
-    response_payload = {
+    data_payload = {
         "symbol": symbol,
         "ohlcv": ohlcv_public,
         "orderflow": orderflow_public,
@@ -3091,4 +3185,95 @@ def build_check_all_datas(
         "context": context_public,
     }
 
-    return round_floats(response_payload)
+    availability: Dict[str, Any] = {
+        "ohlcv": {},
+        "vwap_sessions": {},
+        "zones": {},
+        "orderflow": {"timeframes": {}, "metrics": {}},
+    }
+    missing_fields: Set[str] = set()
+
+    for tf in ("1m", "3m", "5m", "15m", "1h", "4h", "1d"):
+        candles_payload = ohlcv_public.get(tf, {})
+        candles = candles_payload.get("candles") if isinstance(candles_payload, Mapping) else []
+        count = len(candles) if isinstance(candles, Sequence) else 0
+        availability["ohlcv"][tf] = {"candles": count, "has_data": count > 0}
+        if count == 0:
+            missing_fields.add(f"ohlcv.{tf}")
+
+    sessions_public = vwap_tpo_public.get("sessions", {}) if isinstance(vwap_tpo_public, Mapping) else {}
+    for session_name in ("asia", "london", "ny"):
+        raw_session = sessions_public.get(session_name) if isinstance(sessions_public, Mapping) else None
+        session_present = isinstance(raw_session, Mapping) and bool(raw_session)
+        metrics_presence: Dict[str, bool] = {}
+        if not session_present:
+            missing_fields.add(f"vwap_tpo.sessions.{session_name}")
+        for metric in ("poc", "vah", "val", "ib_high", "ib_low"):
+            metric_value = raw_session.get(metric) if isinstance(raw_session, Mapping) else None
+            has_metric = metric_value is not None
+            metrics_presence[metric] = has_metric
+            if not has_metric:
+                missing_fields.add(f"vwap_tpo.sessions.{session_name}.{metric}")
+        availability["vwap_sessions"][session_name] = {
+            "present": session_present,
+            "metrics": metrics_presence,
+        }
+
+    for zone_key, series in zones_public.items():
+        count = len(series) if isinstance(series, Sequence) else 0
+        availability["zones"][zone_key] = {"count": count}
+        if count == 0:
+            missing_fields.add(f"zones.{zone_key}")
+
+    orderflow_metrics = {"footprint": False, "delta": False, "cvd": False}
+    orderflow_source = snapshot.get("orderflow") if isinstance(snapshot.get("orderflow"), Mapping) else None
+    if isinstance(orderflow_source, Mapping):
+        footprint_payload = orderflow_source.get("footprint")
+        if isinstance(footprint_payload, Sequence) and footprint_payload:
+            orderflow_metrics["footprint"] = True
+
+    for tf, payload in orderflow_public.items():
+        per_bar = payload.get("per_bar") if isinstance(payload, Mapping) else []
+        series = per_bar if isinstance(per_bar, Sequence) else []
+        series_list = [entry for entry in series if isinstance(entry, Mapping)]
+        availability["orderflow"]["timeframes"][tf] = {
+            "bars": len(series_list),
+            "has_data": len(series_list) > 0,
+        }
+        if not series_list:
+            missing_fields.add(f"orderflow.{tf}")
+        if series_list:
+            if any(entry.get("delta") is not None for entry in series_list):
+                orderflow_metrics["delta"] = True
+            if any(entry.get("cvd") is not None for entry in series_list):
+                orderflow_metrics["cvd"] = True
+
+    for metric, present in orderflow_metrics.items():
+        if not present:
+            missing_fields.add(f"orderflow.{metric}")
+    availability["orderflow"]["metrics"] = orderflow_metrics
+
+    missing_fields_list = sorted(missing_fields)
+    if missing_fields_list:
+        LOGGER.info("Missing fields detected", extra={"missing_fields": missing_fields_list})
+
+    meta_block: Dict[str, Any] = {
+        "symbol": symbol,
+        "tz": "Europe/Berlin",
+        "last_price": last_price_value,
+        "last_ts_utc": last_iso_ts,
+        "last_tf": last_tf,
+    }
+    if snapshot_age_sec is not None:
+        meta_block["snapshot_age_sec"] = snapshot_age_sec
+    if insufficient_reason:
+        meta_block["insufficient_reason"] = insufficient_reason
+
+    final_payload = {
+        "meta": meta_block,
+        "data": data_payload,
+        "availability": availability,
+        "missing_fields": missing_fields_list,
+    }
+
+    return round_floats(final_payload)

--- a/src/services/inspection.py
+++ b/src/services/inspection.py
@@ -3036,15 +3036,16 @@ def render_inspection_page(
         checkAllHours.value = String(state.hours);
       }
       const presetReady = !state.presetRequired;
+      const liveCapable = Boolean(activeSymbol());
       if (collectSelectionButton) {
         collectSelectionButton.disabled =
           !state.snapshotId || !hasSelection || !hoursValid || !presetReady;
       }
       if (summaryButton) {
-        summaryButton.disabled = !state.snapshotId || !presetReady;
+        summaryButton.disabled = !liveCapable || !presetReady;
       }
       if (topupButton) {
-        topupButton.disabled = !state.snapshotId || !presetReady;
+        topupButton.disabled = !liveCapable || !presetReady;
       }
     }
 
@@ -3178,20 +3179,178 @@ def render_inspection_page(
       }
     }
 
-    async function requestSummaryData() {
-      if (!state.snapshotId) {
-        updateStatus("Выберите снэпшот для сбора контекста", "warning");
-        return;
+    function resolveLiveMetaSnapshot() {
+      if (priceStore && typeof priceStore.getMeta === "function") {
+        try {
+          const meta = priceStore.getMeta();
+          if (meta && typeof meta === "object") {
+            return { ...meta };
+          }
+        } catch (error) {
+          console.warn("Не удалось получить метаданные лайв-стрима", error);
+        }
       }
+      if (state.liveMeta && typeof state.liveMeta === "object") {
+        return { ...state.liveMeta };
+      }
+      return null;
+    }
 
+    function resolveLiveRangeEndMs(meta) {
+      const candidates = [];
+      if (meta && Number.isFinite(meta.last_ts_ms)) {
+        candidates.push(Number(meta.last_ts_ms));
+      }
+      if (priceStore && typeof priceStore.getLastCandle === "function") {
+        try {
+          const last = priceStore.getLastCandle();
+          if (last) {
+            const preview = ensurePreviewBar(last);
+            if (preview) {
+              const ts = Number.isFinite(preview.ts_ms_utc)
+                ? Math.floor(preview.ts_ms_utc)
+                : Math.floor(preview.time * 1000);
+              if (Number.isFinite(ts)) {
+                candidates.push(ts);
+              }
+            }
+          }
+        } catch (error) {
+          console.warn("Не удалось прочитать последнюю свечу лайв-потока", error);
+        }
+      }
+      const minuteLive = state.liveFrames?.["1m"]?.candles;
+      if (Array.isArray(minuteLive) && minuteLive.length) {
+        const preview = ensurePreviewBar(minuteLive[minuteLive.length - 1]);
+        if (preview) {
+          const ts = Number.isFinite(preview.ts_ms_utc)
+            ? Math.floor(preview.ts_ms_utc)
+            : Math.floor(preview.time * 1000);
+          if (Number.isFinite(ts)) {
+            candidates.push(ts);
+          }
+        }
+      }
+      const finite = candidates.filter((value) => Number.isFinite(value));
+      if (!finite.length) {
+        return Date.now();
+      }
+      return Math.max(...finite);
+    }
+
+    function normaliseSnapshotCandles(candles) {
+      const result = [];
+      const seen = new Set();
+      for (const candle of Array.isArray(candles) ? candles : []) {
+        const preview = ensurePreviewBar(candle);
+        if (!preview) continue;
+        const ts = Number.isFinite(preview.ts_ms_utc)
+          ? Math.floor(preview.ts_ms_utc)
+          : Math.floor(preview.time * 1000);
+        if (!Number.isFinite(ts) || seen.has(ts)) continue;
+        seen.add(ts);
+        const volumeSource = Number(
+          candle?.v ??
+            candle?.volume ??
+            candle?.vol ??
+            candle?.qty ??
+            Number.NaN,
+        );
+        const volume = Number.isFinite(volumeSource) ? Math.max(volumeSource, 1e-9) : 1e-9;
+        result.push({
+          t: ts,
+          o: Number(preview.open),
+          h: Number(preview.high),
+          l: Number(preview.low),
+          c: Number(preview.close),
+          v: volume,
+        });
+      }
+      result.sort((a, b) => a.t - b.t);
+      return result.slice(-5000);
+    }
+
+    async function captureLiveSnapshot(options = {}) {
+      const lookbackDaysRaw = Number(options?.lookbackDays);
+      const lookbackDays = Number.isFinite(lookbackDaysRaw)
+        ? Math.max(1, Math.floor(lookbackDaysRaw))
+        : 3;
+      const mode = typeof options?.mode === "string" ? options.mode : "summary";
+      const symbol = activeSymbol();
+      if (!symbol) {
+        throw new Error("live-snapshot-symbol-missing");
+      }
+      const liveMeta = resolveLiveMetaSnapshot();
+      const endMs = resolveLiveRangeEndMs(liveMeta);
+      const lookbackMs = lookbackDays * 24 * 60 * 60 * 1000;
+      const startMs = Math.max(0, Math.floor(endMs - lookbackMs));
+      const rawCandles = await fetchCandles(symbol, "1m", startMs, endMs, { limit: 1500 });
+      const candles = normaliseSnapshotCandles(rawCandles);
+      if (!candles.length) {
+        throw new Error("live-snapshot-empty");
+      }
+      const frames = { "1m": { tf: "1m", candles } };
+      const metaBlock = {
+        source: {
+          kind: "live-store",
+          mode,
+          lookback_days: lookbackDays,
+          captured_at: new Date().toISOString(),
+        },
+        requested: {
+          frames: Object.keys(frames),
+          lookback_days: lookbackDays,
+        },
+      };
+      if (liveMeta) {
+        const livePayload = {
+          last_price: Number.isFinite(liveMeta.last_price) ? Number(liveMeta.last_price) : null,
+          last_tf: liveMeta.last_tf || "1m",
+          last_ts_ms: Number.isFinite(liveMeta.last_ts_ms) ? Number(liveMeta.last_ts_ms) : null,
+          age_sec: Number.isFinite(liveMeta.age_sec) ? Number(liveMeta.age_sec) : null,
+          stale: Boolean(liveMeta.stale),
+          mismatch: Boolean(liveMeta.mismatch),
+        };
+        metaBlock.live = livePayload;
+        metaBlock.stream = livePayload;
+        metaBlock.live_price = livePayload;
+      }
+      const payload = {
+        symbol,
+        tf: "1m",
+        candles,
+        frames,
+        meta: metaBlock,
+        lookback_days: lookbackDays,
+      };
+      const result = await postSnapshot(payload);
+      if (!result || !result.snapshot_id) {
+        throw new Error("live-snapshot-registration-failed");
+      }
+      return { snapshotId: result.snapshot_id, payload };
+    }
+
+    async function requestSummaryData() {
       if (summaryButton) {
         summaryButton.disabled = true;
       }
 
+      let createdSnapshotId = null;
+
       try {
-        updateStatus("Собираем данные за последние 3 дня...", "info");
+        updateStatus("Собираем лайв-данные за последние 3 дня...", "info");
+        const { snapshotId } = await captureLiveSnapshot({ lookbackDays: 3, mode: "summary" });
+        createdSnapshotId = snapshotId;
+        state.snapshotId = snapshotId;
+        updateCheckAllState();
+        if (summaryButton) {
+          summaryButton.disabled = true;
+        }
+        if (snapshotSelect) {
+          snapshotSelect.value = snapshotId;
+        }
         const url = new URL("/inspection/check-all", window.location.origin);
-        url.searchParams.set("snapshot", state.snapshotId);
+        url.searchParams.set("snapshot", snapshotId);
         url.searchParams.set("mode", "summary");
         url.searchParams.set("summary_days", "3");
         const response = await fetch(url.toString(), {
@@ -3217,24 +3376,39 @@ def render_inspection_page(
         setJson(checkAllPre, null);
         updateStatus("Ошибка при сборе 3-дневного контекста", "error");
       } finally {
+        if (summaryButton) {
+          summaryButton.disabled = false;
+        }
+        if (createdSnapshotId) {
+          refreshSnapshots({ quiet: true }).catch((err) => {
+            console.warn("Не удалось обновить список снэпшотов", err);
+          });
+        }
         updateCheckAllState();
       }
     }
 
     async function requestTopupData() {
-      if (!state.snapshotId) {
-        updateStatus("Выберите снэпшот для досбора", "warning");
-        return;
-      }
-
       if (topupButton) {
         topupButton.disabled = true;
       }
 
+      let createdSnapshotId = null;
+
       try {
-        updateStatus("Дособираем свежие данные...", "info");
+        updateStatus("Дособираем свежие лайв-данные...", "info");
+        const { snapshotId } = await captureLiveSnapshot({ lookbackDays: 1, mode: "topup" });
+        createdSnapshotId = snapshotId;
+        state.snapshotId = snapshotId;
+        updateCheckAllState();
+        if (topupButton) {
+          topupButton.disabled = true;
+        }
+        if (snapshotSelect) {
+          snapshotSelect.value = snapshotId;
+        }
         const url = new URL("/inspection/check-all", window.location.origin);
-        url.searchParams.set("snapshot", state.snapshotId);
+        url.searchParams.set("snapshot", snapshotId);
         url.searchParams.set("mode", "topup");
         const response = await fetch(url.toString(), {
           headers: { Accept: "application/json" },
@@ -3259,6 +3433,14 @@ def render_inspection_page(
         setJson(checkAllPre, null);
         updateStatus("Ошибка при досборе данных", "error");
       } finally {
+        if (topupButton) {
+          topupButton.disabled = false;
+        }
+        if (createdSnapshotId) {
+          refreshSnapshots({ quiet: true }).catch((err) => {
+            console.warn("Не удалось обновить список снэпшотов", err);
+          });
+        }
         updateCheckAllState();
       }
     }
@@ -3744,14 +3926,17 @@ def render_inspection_page(
         });
     }
 
-    async function refreshSnapshots() {
+    async function refreshSnapshots(options = {}) {
+      const quiet = Boolean(options?.quiet);
       try {
         const list = await fetchSnapshots();
         initial.snapshots = list;
         populateSnapshots(list);
       } catch (error) {
         console.error(error);
-        updateStatus("Не удалось загрузить список снэпшотов", "error");
+        if (!quiet) {
+          updateStatus("Не удалось загрузить список снэпшотов", "error");
+        }
       }
     }
 

--- a/src/services/inspection.py
+++ b/src/services/inspection.py
@@ -2494,9 +2494,11 @@ def render_inspection_page(
 
     const PREFERRED_CHART_FRAMES = ["1m", "3m", "15m", "30m", "1h", "4h", "1d", "1w"];
 
+    let state = null;
+
     function frameHasCandles(frames, tf) {
       if (!tf) return false;
-      const liveEntry = state.liveFrames?.[tf];
+      const liveEntry = state?.liveFrames?.[tf];
       if (liveEntry && Array.isArray(liveEntry.candles) && liveEntry.candles.length) {
         return true;
       }
@@ -2527,7 +2529,7 @@ def render_inspection_page(
     const initialFrameMap = initial.payload?.DATA?.frames || {};
     const defaultFrame = selectPreferredFrame(initialFrameMap, initial.timeframe);
 
-    const state = {
+    state = {
       payload: initial.payload || null,
       snapshotId: initial.snapshotId || null,
       selection: initial.payload?.DATA?.selection || null,

--- a/src/services/inspection.py
+++ b/src/services/inspection.py
@@ -42,6 +42,7 @@ from .profile import build_profile_package
 from .presets import resolve_profile_config
 from .zones import Config as ZonesConfig, detect_zones
 from ..meta import Meta
+from ..static_version import STATIC_VERSION
 
 Snapshot = Dict[str, Any]
 
@@ -1465,6 +1466,7 @@ def render_inspection_page(
 ) -> str:
     """Render the inspection dashboard HTML."""
 
+    static_version = STATIC_VERSION
     payload_json = json.dumps(payload, ensure_ascii=False).replace("</", "<\\/")
     snapshots_json = json.dumps(snapshots, ensure_ascii=False).replace("</", "<\\/")
 
@@ -1660,6 +1662,35 @@ def render_inspection_page(
       gap: 0.6rem;
       align-items: center;
       flex-wrap: wrap;
+    }
+    .live-meta {
+      margin-top: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 0.75rem;
+      padding: 0.85rem 1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      background: rgba(15, 23, 42, 0.68);
+      box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+    }
+    .live-meta__item span {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .live-meta__value {
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: #f8fafc;
+    }
+    .live-meta__value[data-state="stale"] {
+      color: #f97316;
+    }
+    .live-meta__value[data-state="fresh"] {
+      color: #22c55e;
     }
     .chart-toolbar {
       display: flex;
@@ -2087,7 +2118,7 @@ def render_inspection_page(
   }
 
   async function fetchSnapshots() {
-    const response = await fetch("/inspection/snapshots");
+    const response = await fetch("/inspection/snapshots", { cache: "no-store" });
     if (!response.ok) throw new Error("Failed to fetch snapshots");
     return response.json();
   }
@@ -2170,7 +2201,7 @@ def render_inspection_page(
       url.searchParams.set("endTime", Math.floor(endMs));
     }
     url.searchParams.set("limit", String(Math.max(1, Math.min(limit, 1500))));
-    const response = await fetch(url.toString());
+    const response = await fetch(url.toString(), { cache: "no-store" });
     if (!response.ok) {
       throw new Error(`Failed to fetch range: ${response.status}`);
     }
@@ -2282,7 +2313,7 @@ def render_inspection_page(
       }
       url.searchParams.set("limit", String(batchLimit));
 
-      const resp = await fetch(url.toString());
+      const resp = await fetch(url.toString(), { cache: "no-store" });
       if (!resp.ok) {
         throw new Error(`klines ${resp.status}`);
       }
@@ -2353,6 +2384,7 @@ def render_inspection_page(
     const response = await fetch("/inspection/snapshot", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      cache: "no-store",
       body: JSON.stringify(payload),
     });
     if (!response.ok) {
@@ -2365,6 +2397,7 @@ def render_inspection_page(
   async function fetchPayload(id) {
     const response = await fetch(`/inspection?snapshot=${encodeURIComponent(id)}`, {
       headers: { Accept: "application/json" },
+      cache: "no-store",
     });
     if (!response.ok) {
       throw new Error("Failed to fetch payload");
@@ -2444,6 +2477,12 @@ def render_inspection_page(
     const presetSubmitButton = document.getElementById("preset-submit");
     const presetCancelButtons = Array.from(document.querySelectorAll("[data-close-preset]"));
     const presetCreateButton = document.getElementById("preset-create-button");
+    const livePriceEl = document.getElementById("live-last-price");
+    const liveTsEl = document.getElementById("live-last-ts");
+    const liveTfEl = document.getElementById("live-last-tf");
+    const liveAgeEl = document.getElementById("live-age-sec");
+    const liveStateEl = document.getElementById("live-stale-flag");
+    const mismatchBanner = document.getElementById("stream-mismatch");
 
     initCollapsibles();
 
@@ -2456,7 +2495,12 @@ def render_inspection_page(
     const PREFERRED_CHART_FRAMES = ["1m", "3m", "15m", "30m", "1h", "4h", "1d", "1w"];
 
     function frameHasCandles(frames, tf) {
-      if (!frames || !tf) return false;
+      if (!tf) return false;
+      const liveEntry = state.liveFrames?.[tf];
+      if (liveEntry && Array.isArray(liveEntry.candles) && liveEntry.candles.length) {
+        return true;
+      }
+      if (!frames) return false;
       const entry = frames[tf];
       if (!entry || typeof entry !== "object") return false;
       const candles = Array.isArray(entry.candles) ? entry.candles : [];
@@ -2506,6 +2550,9 @@ def render_inspection_page(
       presetModalMode: null,
       managingSymbol: null,
       presetModalOpen: false,
+      liveFrames: {},
+      liveMeta: null,
+      liveMismatch: false,
     };
 
     const AUTO_PRESET_SYMBOLS = new Set(["BTCUSDT", "ETHUSDT", "SOLUSDT"]);
@@ -2523,6 +2570,151 @@ def render_inspection_page(
         normaliseSymbol(initial.symbol) ||
         defaultSymbol
       );
+    }
+
+    const MarketDataStore = window.MarketDataStore || null;
+    const chartStore =
+      MarketDataStore &&
+      new MarketDataStore({
+        symbol: activeSymbol(),
+        interval: state.frame || "1m",
+        pollIntervalMs: 1500,
+        historyLimit: 1500,
+      });
+    const priceStore =
+      MarketDataStore &&
+      new MarketDataStore({
+        symbol: activeSymbol(),
+        interval: "1m",
+        pollIntervalMs: 1500,
+        historyLimit: 1500,
+      });
+
+    function formatLivePrice(value) {
+      if (!Number.isFinite(value)) return "—";
+      const abs = Math.abs(value);
+      if (abs >= 100_000) return value.toFixed(1);
+      if (abs >= 10_000) return value.toFixed(2);
+      if (abs >= 1_000) return value.toFixed(2);
+      if (abs >= 100) return value.toFixed(2);
+      if (abs >= 10) return value.toFixed(3);
+      if (abs >= 1) return value.toFixed(4);
+      if (abs >= 0.1) return value.toFixed(5);
+      return value.toFixed(6);
+    }
+
+    function renderLiveMeta(meta) {
+      state.liveMeta = meta || null;
+      if (!meta) {
+        if (livePriceEl) livePriceEl.textContent = "—";
+        if (liveTsEl) liveTsEl.textContent = "—";
+        if (liveTfEl) liveTfEl.textContent = "—";
+        if (liveAgeEl) liveAgeEl.textContent = "—";
+        if (liveStateEl) {
+          liveStateEl.textContent = "—";
+          liveStateEl.dataset.state = "unknown";
+        }
+        if (mismatchBanner) mismatchBanner.hidden = true;
+        return;
+      }
+      if (livePriceEl) livePriceEl.textContent = formatLivePrice(meta.last_price);
+      if (liveTsEl) liveTsEl.textContent = meta.last_ts_ms ? formatTs(meta.last_ts_ms) : "—";
+      if (liveTfEl) liveTfEl.textContent = meta.last_tf || "—";
+      if (liveAgeEl) liveAgeEl.textContent = Number.isFinite(meta.age_sec) ? `${meta.age_sec}s` : "—";
+      if (liveStateEl) {
+        liveStateEl.textContent = meta.stale ? "Stale" : "Live";
+        liveStateEl.dataset.state = meta.stale ? "stale" : "fresh";
+      }
+      state.liveMismatch = Boolean(meta.mismatch);
+      if (mismatchBanner) {
+        mismatchBanner.hidden = !state.liveMismatch;
+        if (state.liveMismatch) {
+          mismatchBanner.dataset.tone = "warning";
+          mismatchBanner.textContent = "Stream vs OHLCV mismatch > 1 tick";
+        }
+      }
+    }
+
+    function syncLiveStores({ force = false } = {}) {
+      const symbol = activeSymbol();
+      const chartInterval = state.frame || "1m";
+      if (chartStore) {
+        chartStore.setSymbol(symbol, chartInterval);
+        if (force) chartStore.restart();
+      }
+      if (priceStore) {
+        priceStore.setSymbol(symbol, "1m");
+        if (force) priceStore.restart();
+      }
+    }
+
+    function handleChartStoreEvent(event) {
+      if (!event || !chartStore) return;
+      const eventSymbol = normaliseSymbol(event.symbol);
+      const currentSymbol = normaliseSymbol(activeSymbol());
+      if (eventSymbol && currentSymbol && eventSymbol !== currentSymbol) return;
+      const tf = event.interval || (state.frame || "1m");
+      const latest = chartStore.candles ? chartStore.candles.slice() : [];
+      if (!state.liveFrames) state.liveFrames = {};
+      if (latest.length) {
+        state.liveFrames[tf] = { tf, candles: latest };
+        state.availableFrames = { ...(state.availableFrames || {}), [tf]: { tf, candles: latest } };
+      }
+
+      if (event.type === "status") {
+        if (event.status === "connected") {
+          updateStatus("Лайв-данные подключены", "info");
+        } else if (event.status === "closed") {
+          updateStatus("Лайв-канал закрыт, используем пуллинг", "warning");
+        } else if (event.status === "error") {
+          updateStatus("Ошибка потока, переподключение...", "warning");
+        }
+        return;
+      }
+      if (event.type === "error") {
+        updateStatus("Ошибка получения лайв-данных", "error");
+        return;
+      }
+
+      if (tf === (state.frame || "1m")) {
+        if (event.type === "snapshot") {
+          mergeChartBars(latest, { reset: true, persist: true });
+          renderChart({ resetRequestedKeys: true, fitContent: true });
+        } else if (event.type === "update" && event.candle) {
+          mergeChartBars([event.candle], { reset: false, persist: true });
+        } else if (event.type === "poll") {
+          const pollBars = Array.isArray(event.candles) ? event.candles : [];
+          if (pollBars.length) {
+            mergeChartBars(pollBars, { reset: false, persist: false });
+          }
+        }
+      }
+
+      updateTimeframeToggle();
+    }
+
+    function handlePriceStoreEvent(event) {
+      if (!event || !priceStore) return;
+      const eventSymbol = normaliseSymbol(event.symbol);
+      const currentSymbol = normaliseSymbol(activeSymbol());
+      if (eventSymbol && currentSymbol && eventSymbol !== currentSymbol) return;
+      if (event.meta) {
+        renderLiveMeta(event.meta);
+      }
+    }
+
+    if (chartStore) {
+      chartStore.subscribe(handleChartStoreEvent);
+      chartStore.start();
+    }
+
+    if (priceStore) {
+      priceStore.subscribe(handlePriceStoreEvent);
+      priceStore.start();
+    }
+
+    if (chartStore || priceStore) {
+      syncLiveStores({ force: true });
     }
 
     function renderChartSymbol() {
@@ -2669,7 +2861,10 @@ def render_inspection_page(
     async function refreshPresetList() {
       if (!presetListContainer) return;
       try {
-        const response = await fetch("/presets", { headers: { Accept: "application/json" } });
+        const response = await fetch("/presets", {
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+        });
         const data = await response.json();
         const list = Array.isArray(data?.presets) ? data.presets : [];
         state.presetList = list;
@@ -2731,7 +2926,10 @@ def render_inspection_page(
         deleteButton.addEventListener("click", async () => {
           if (!window.confirm(`Удалить пресет ${symbol}?`)) return;
           try {
-            const response = await fetch(`/presets/${symbol}`, { method: "DELETE" });
+            const response = await fetch(`/presets/${symbol}`, {
+              method: "DELETE",
+              cache: "no-store",
+            });
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             if (normaliseSymbol(symbol) === normaliseSymbol(activeSymbol())) {
               state.profilePreset = null;
@@ -2764,6 +2962,7 @@ def render_inspection_page(
         const response = await fetch(url, {
           method,
           headers: { "Content-Type": "application/json", Accept: "application/json" },
+          cache: "no-store",
           body: JSON.stringify(payload),
         });
         if (!response.ok) {
@@ -2807,6 +3006,9 @@ def render_inspection_page(
       renderChartSymbol();
       symbolInput.addEventListener("input", () => {
         renderChartSymbol();
+      });
+      symbolInput.addEventListener("change", () => {
+        syncLiveStores({ force: true });
       });
     }
 
@@ -2865,8 +3067,15 @@ def render_inspection_page(
 
     function populateFrames(payload) {
       const frames = payload?.DATA?.frames || {};
-      state.availableFrames = frames;
-      const target = selectPreferredFrame(frames, state.frame);
+      const combined = { ...frames };
+      if (state.liveFrames) {
+        Object.entries(state.liveFrames).forEach(([tf, entry]) => {
+          if (!tf) return;
+          combined[tf] = { tf, candles: entry?.candles || [] };
+        });
+      }
+      state.availableFrames = combined;
+      const target = selectPreferredFrame(combined, state.frame);
       state.frame = target;
       updateTimeframeToggle();
     }
@@ -2942,6 +3151,7 @@ def render_inspection_page(
         url.searchParams.set("hours", String(state.hours));
         const response = await fetch(url.toString(), {
           headers: { Accept: "application/json" },
+          cache: "no-store",
         });
         if (response.status === 204) {
           state.checkAll = null;
@@ -2984,6 +3194,7 @@ def render_inspection_page(
         url.searchParams.set("summary_days", "3");
         const response = await fetch(url.toString(), {
           headers: { Accept: "application/json" },
+          cache: "no-store",
         });
         if (response.status === 204) {
           state.checkAll = null;
@@ -3025,6 +3236,7 @@ def render_inspection_page(
         url.searchParams.set("mode", "topup");
         const response = await fetch(url.toString(), {
           headers: { Accept: "application/json" },
+          cache: "no-store",
         });
         if (response.status === 204) {
           state.checkAll = null;
@@ -3329,7 +3541,10 @@ def render_inspection_page(
 
     function updateChartDataFromFrame(options = {}) {
       const { resetRequestedKeys = false, persist = false } = options;
-      const frameCandles = state.payload?.DATA?.frames?.[state.frame]?.candles || [];
+      let frameCandles = state.liveFrames?.[state.frame]?.candles;
+      if (!Array.isArray(frameCandles) || !frameCandles.length) {
+        frameCandles = state.payload?.DATA?.frames?.[state.frame]?.candles || [];
+      }
       const bars = toChartBars(frameCandles);
       mergeChartBars(bars, { reset: true, persist });
       state.intervalMs = intervalToMs(state.frame || "1m");
@@ -3456,6 +3671,15 @@ def render_inspection_page(
       const timeframe = state.frame || "1m";
       state.intervalMs = intervalToMs(timeframe);
       const symbol = activeSymbol();
+      const liveEntry = state.liveFrames?.[timeframe];
+      if (liveEntry && Array.isArray(liveEntry.candles) && liveEntry.candles.length) {
+        mergeChartBars(liveEntry.candles, { reset: true, persist: false });
+        ensureGapWatcher({ resetRequestedKeys });
+        if (fitContent && state.chart && state.candles.length) {
+          state.chart.timeScale().fitContent();
+        }
+        return Promise.resolve(true);
+      }
       const hasFrameData = frameHasCandles(frames, timeframe);
 
       if (hasFrameData) {
@@ -3551,6 +3775,7 @@ def render_inspection_page(
           renderChartSymbol();
         }
         populateFrames(payload);
+        syncLiveStores({ force: true });
         renderJson(payload);
         renderMeta(payload);
         renderChart({ resetRequestedKeys: true, fitContent: true });
@@ -3577,6 +3802,7 @@ def render_inspection_page(
         state.frame = tf;
         renderChart({ resetRequestedKeys: true });
         updateTimeframeToggle();
+        syncLiveStores({ force: true });
       });
     }
 
@@ -3829,6 +4055,29 @@ def render_inspection_page(
                 <button id=\"clear-selection\" class=\"secondary\" type=\"button\">Сбросить выделение</button>
               </div>
             </div>
+            <div class=\"live-meta\" id=\"live-meta\">
+              <div class=\"live-meta__item\">
+                <span>Последняя цена</span>
+                <strong id=\"live-last-price\" class=\"live-meta__value\">—</strong>
+              </div>
+              <div class=\"live-meta__item\">
+                <span>Обновлено (UTC)</span>
+                <strong id=\"live-last-ts\" class=\"live-meta__value\">—</strong>
+              </div>
+              <div class=\"live-meta__item\">
+                <span>Таймфрейм</span>
+                <strong id=\"live-last-tf\" class=\"live-meta__value\">—</strong>
+              </div>
+              <div class=\"live-meta__item\">
+                <span>Возраст</span>
+                <strong id=\"live-age-sec\" class=\"live-meta__value\">—</strong>
+              </div>
+              <div class=\"live-meta__item\">
+                <span>Статус</span>
+                <strong id=\"live-stale-flag\" class=\"live-meta__value\" data-state=\"unknown\">—</strong>
+              </div>
+            </div>
+            <div class=\"status-banner\" id=\"stream-mismatch\" hidden data-tone=\"warning\">Stream vs OHLCV mismatch &gt; 1 tick</div>
             <div id=\"snapshot-meta\"></div>
           </section>
 
@@ -3959,9 +4208,10 @@ def render_inspection_page(
         </main>
         <script>{script_block}</script>
         <script src=\"https://unpkg.com/lightweight-charts@4.0.0/dist/lightweight-charts.standalone.production.js\"></script>
-        <script src="/public/binanceCandles.js"></script>
-        <script src="/public/chart-gap-watcher.js"></script>
-        <script src="/public/shared-candles.js"></script>
+        <script src="/public/binanceCandles.js?v={static_version}"></script>
+        <script src="/public/chart-gap-watcher.js?v={static_version}"></script>
+        <script src="/public/shared-candles.js?v={static_version}"></script>
+        <script src="/public/market-data-store.js?v={static_version}"></script>
         <script>{ui_script}</script>
       </body>
     </html>

--- a/src/static_version.py
+++ b/src/static_version.py
@@ -1,0 +1,9 @@
+"""Static asset cache-busting helpers."""
+
+from datetime import datetime, timezone
+
+from .version import APP_VERSION
+
+STATIC_VERSION = f"{APP_VERSION}-{int(datetime.now(timezone.utc).timestamp())}"
+
+__all__ = ["STATIC_VERSION"]

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,12 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Свечной график Binance</title>
-    <link rel="stylesheet" href="/public/styles.css" />
+    <link rel="stylesheet" href="/public/styles.css?v=__STATIC_VERSION__" />
     <script src="https://unpkg.com/lightweight-charts@4.0.0/dist/lightweight-charts.standalone.production.js"></script>
-    <script src="/public/binanceCandles.js" defer></script>
-    <script src="/public/chart-gap-watcher.js" defer></script>
-    <script src="/public/shared-candles.js" defer></script>
-    <script src="/public/app.js" defer></script>
+    <script src="/public/binanceCandles.js?v=__STATIC_VERSION__" defer></script>
+    <script src="/public/chart-gap-watcher.js?v=__STATIC_VERSION__" defer></script>
+    <script src="/public/shared-candles.js?v=__STATIC_VERSION__" defer></script>
+    <script src="/public/market-data-store.js?v=__STATIC_VERSION__" defer></script>
+    <script src="/public/app.js?v=__STATIC_VERSION__" defer></script>
   </head>
   <body>
     <header class="page-header">

--- a/tests/test_api_payload_schema.py
+++ b/tests/test_api_payload_schema.py
@@ -140,13 +140,14 @@ def test_check_all_sessions_include_extrema(client: TestClient) -> None:
     )
     assert response.status_code == 200
     body = response.json()
+    data_block = body["data"]
 
-    vwap_sessions = body["vwap_tpo"]["sessions"]
+    vwap_sessions = data_block["vwap_tpo"]["sessions"]
     for session_name, session_payload in vwap_sessions.items():
         assert session_payload["high"] is not None
         assert session_payload["low"] is not None
 
-    composite_day = body["tpo"]["composite_day"]
+    composite_day = data_block["tpo"]["composite_day"]
     assert set(composite_day.keys()) == {"poc", "vah", "val"}
 
 

--- a/tests/test_check_all_datas.py
+++ b/tests/test_check_all_datas.py
@@ -158,32 +158,28 @@ def test_check_all_returns_structured_payload(client: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
 
-    expected_order = [
-        "symbol",
-        "ohlcv",
-        "orderflow",
-        "vwap_tpo",
-        "tpo",
-        "prev_day",
-        "zones",
-        "liquidity",
-        "risk_prefs",
-        "context",
-    ]
-    assert list(body.keys()) == expected_order
-    assert body["symbol"] == payload["symbol"]
+    assert set(body.keys()) == {"meta", "data", "availability", "missing_fields"}
 
-    ohlcv = body["ohlcv"]
+    meta = body["meta"]
+    assert meta["symbol"] == payload["symbol"]
+    assert meta["tz"] == "Europe/Berlin"
+    assert "last_price" in meta
+    assert "last_ts_utc" in meta
+    assert "last_tf" in meta
+
+    data_block = body["data"]
+
+    ohlcv = data_block["ohlcv"]
     assert set(ohlcv.keys()) == {"1m", "3m", "5m", "15m", "1h", "4h", "1d"}
     for series in ohlcv.values():
         assert isinstance(series["candles"], list)
 
-    orderflow = body["orderflow"]
+    orderflow = data_block["orderflow"]
     assert set(orderflow.keys()) == {"15m", "1h"}
     for block in orderflow.values():
         assert isinstance(block["per_bar"], list)
 
-    vwap_tpo = body["vwap_tpo"]
+    vwap_tpo = data_block["vwap_tpo"]
     assert vwap_tpo["daily"]["open_utc"].startswith("2024-01-02T00:00:00")
     assert set(vwap_tpo["sessions"].keys()) == {"asia", "london", "ny"}
     for session_payload in vwap_tpo["sessions"].values():
@@ -202,10 +198,10 @@ def test_check_all_returns_structured_payload(client: TestClient) -> None:
             "low",
         }
 
-    composite_day = body["tpo"]["composite_day"]
+    composite_day = data_block["tpo"]["composite_day"]
     assert set(composite_day.keys()) == {"poc", "vah", "val"}
 
-    prev_day = body["prev_day"]
+    prev_day = data_block["prev_day"]
     assert set(prev_day.keys()) == {"pdh", "pdl", "close", "poc", "vah", "val"}
     prev_minutes = payload["candles"][: 60 * 24]
     expected_high = max(candle["h"] for candle in prev_minutes)
@@ -215,18 +211,29 @@ def test_check_all_returns_structured_payload(client: TestClient) -> None:
     assert prev_day["pdl"] == pytest.approx(expected_low)
     assert prev_day["close"] == pytest.approx(expected_close)
 
-    zones = body["zones"]
-    assert set(zones.keys()) == {"fvg", "ob", "mb", "bb", "rb", "pb", "sr", "profile_levels"}
+    zones = data_block["zones"]
+    assert set(zones.keys()) == {"fvg", "fvl", "ob", "mb", "bb", "rb", "pb", "sr", "profile_levels"}
     for zone_series in zones.values():
         assert isinstance(zone_series, list)
 
-    liquidity = body["liquidity"]
+    liquidity = data_block["liquidity"]
     assert set(liquidity.keys()) == {"eqh", "eql"}
     for levels in liquidity.values():
         assert isinstance(levels, list)
 
-    assert body["risk_prefs"] == {"rr_min": pytest.approx(2.5), "risk_per_trade_pct": pytest.approx(1.0)}
-    assert body["context"] == {"globalBias": "neutral", "narrative": "", "openOppositeZones": False}
+    assert data_block["risk_prefs"] == {
+        "rr_min": pytest.approx(2.5),
+        "risk_per_trade_pct": pytest.approx(1.0),
+    }
+    assert data_block["context"] == {
+        "globalBias": "neutral",
+        "narrative": "",
+        "openOppositeZones": False,
+    }
+
+    availability = body["availability"]
+    assert set(availability.keys()) == {"ohlcv", "vwap_sessions", "zones", "orderflow"}
+    assert isinstance(body["missing_fields"], list)
 
 
 def test_topup_limits_window_to_last_collection(client: TestClient) -> None:
@@ -248,9 +255,10 @@ def test_topup_limits_window_to_last_collection(client: TestClient) -> None:
         )
         assert response.status_code == 200
         body = response.json()
+        zones_block = body["data"]["zones"]
 
         for zone_key in ("fvg", "ob", "mb", "bb", "rb", "pb", "sr"):
-            zone_entries = body["zones"].get(zone_key, [])
+            zone_entries = zones_block.get(zone_key, [])
             assert zone_entries, f"expected informational entry for {zone_key}"
             message_entry = zone_entries[0]
             assert "message" in message_entry
@@ -271,7 +279,7 @@ def test_multi_timeframe_ohlcv_alignment(client: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
 
-    ohlcv_block = body["ohlcv"]
+    ohlcv_block = body["data"]["ohlcv"]
     assert ohlcv_block["1m"]["candles"]
 
     minute_map = {candle["t"]: candle for candle in ohlcv_block["1m"]["candles"]}
@@ -330,7 +338,7 @@ def test_orderflow_block_matches_spec(client: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
 
-    orderflow_block = body["orderflow"]
+    orderflow_block = body["data"]["orderflow"]
     assert set(orderflow_block.keys()) == {"15m", "1h"}
 
     fifteen_series = orderflow_block["15m"]["per_bar"]
@@ -369,7 +377,7 @@ def test_vwap_tpo_sessions_include_aliases(client: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
 
-    sessions = body["vwap_tpo"]["sessions"]
+    sessions = body["data"]["vwap_tpo"]["sessions"]
     ny_session = sessions["ny"]
     assert ny_session["open_utc"].endswith("13:30:00Z")
     assert ny_session["close_utc"].endswith("16:30:00Z")
@@ -378,7 +386,7 @@ def test_vwap_tpo_sessions_include_aliases(client: TestClient) -> None:
     assert "ib_high" in ny_session
     assert "ib_low" in ny_session
 
-    composite_day = body["tpo"]["composite_day"]
+    composite_day = body["data"]["tpo"]["composite_day"]
     assert composite_day["poc"] is not None
     assert composite_day["vah"] is not None
     assert composite_day["val"] is not None

--- a/tests/test_check_all_datas.py
+++ b/tests/test_check_all_datas.py
@@ -166,6 +166,8 @@ def test_check_all_returns_structured_payload(client: TestClient) -> None:
     assert "last_price" in meta
     assert "last_ts_utc" in meta
     assert "last_tf" in meta
+    assert meta["last_price_source"] in {"stream", "ohlcv"}
+    assert "stale" in meta
 
     data_block = body["data"]
 

--- a/tests/test_last_price_meta.py
+++ b/tests/test_last_price_meta.py
@@ -11,7 +11,7 @@ UTC = timezone.utc
 @pytest.fixture()
 def stub_check_all_dependencies(monkeypatch):
     def fake_profile_config(symbol: str, meta: Dict[str, Any] | None) -> Dict[str, Any]:
-        return {}
+        return {"tick_size": 0.5}
 
     def fake_profile_package(*args, **kwargs):
         return ([], [], [])
@@ -57,6 +57,7 @@ def stub_check_all_dependencies(monkeypatch):
     monkeypatch.setattr(check_all_datas, "build_profile_package", fake_profile_package)
     monkeypatch.setattr(check_all_datas, "detect_zones", fake_detect_zones)
     monkeypatch.setattr(check_all_datas, "build_liquidity_snapshot", fake_liquidity)
+    monkeypatch.setattr(check_all_datas, "resolve_liquidity_tick_size", lambda *args, **kwargs: (0.5, "stub"))
     monkeypatch.setattr(check_all_datas, "build_multi_timeframe_ohlcv", fake_multi_tf)
     monkeypatch.setattr(check_all_datas, "aggregate_1m_to_1h", fake_aggregate)
     monkeypatch.setattr(check_all_datas, "detect_smc_blocks", fake_smc)
@@ -101,6 +102,8 @@ def test_last_price_prefers_minute_candle_over_analysis(stub_check_all_dependenc
     assert meta["last_price"] == pytest.approx(116.0)
     assert meta["last_tf"] == "1m"
     assert meta.get("insufficient_reason") is None
+    assert meta["last_price_source"] == "ohlcv"
+    assert meta["stale"] is False
 
 
 def test_snapshot_staleness_marks_meta(stub_check_all_dependencies) -> None:
@@ -127,6 +130,7 @@ def test_snapshot_staleness_marks_meta(stub_check_all_dependencies) -> None:
     assert meta["snapshot_age_sec"] >= 600
     reason = meta.get("insufficient_reason")
     assert isinstance(reason, str) and reason.startswith("stale_snapshot_")
+    assert meta["stale"] is True
 
 
 def test_last_price_updates_when_minute_candles_change(stub_check_all_dependencies) -> None:
@@ -171,3 +175,59 @@ def test_last_price_updates_when_minute_candles_change(stub_check_all_dependenci
     refreshed = check_all_datas.build_check_all_datas(snapshot, now_utc=base + timedelta(minutes=3))
     assert refreshed["meta"]["last_price"] == pytest.approx(123.0)
     assert refreshed["meta"]["last_tf"] == "1m"
+    assert refreshed["meta"]["last_price_source"] == "ohlcv"
+
+
+def test_stream_price_overrides_candle(stub_check_all_dependencies) -> None:
+    base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+    candles = [
+        {
+            "t": int((base + timedelta(minutes=0)).timestamp() * 1000),
+            "o": 100.0,
+            "h": 110.0,
+            "l": 95.0,
+            "c": 105.0,
+            "v": 3.0,
+        },
+    ]
+    snapshot = _snapshot_with_candles(candles, entry_price=101.0)
+    stream_ts = int((base + timedelta(minutes=1, seconds=2)).timestamp() * 1000)
+    snapshot["stream"] = {"price": 107.5, "ts": stream_ts}
+
+    result = check_all_datas.build_check_all_datas(snapshot, now_utc=base + timedelta(minutes=1, seconds=3))
+
+    meta = result["meta"]
+    assert meta["last_price"] == pytest.approx(107.5)
+    assert meta["last_tf"] == "stream"
+    assert meta["last_price_source"] == "stream"
+    assert meta.get("stale") is False
+    assert meta.get("insufficient_reason") is None
+
+
+def test_stream_vs_ohlcv_mismatch_flag(stub_check_all_dependencies) -> None:
+    base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+    candle_ts = int(base.timestamp() * 1000)
+    candles = [
+        {
+            "t": candle_ts,
+            "o": 100.0,
+            "h": 110.0,
+            "l": 95.0,
+            "c": 100.0,
+            "v": 3.0,
+        }
+    ]
+    snapshot = _snapshot_with_candles(candles, entry_price=100.0)
+    stream_ts = candle_ts + 60_000 + 4_000
+    snapshot["stream"] = {"price": 101.5, "ts": stream_ts}
+
+    result = check_all_datas.build_check_all_datas(
+        snapshot,
+        now_utc=base + timedelta(minutes=1, seconds=10),
+    )
+
+    meta = result["meta"]
+    assert meta["last_price_source"] == "stream"
+    assert meta["last_price"] == pytest.approx(101.5)
+    assert meta.get("stream_vs_ohlcv_mismatch") is True
+    assert meta.get("insufficient_reason") is None

--- a/tests/test_last_price_meta.py
+++ b/tests/test_last_price_meta.py
@@ -1,0 +1,173 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Sequence
+
+import pytest
+
+import src.services.check_all_datas as check_all_datas
+
+UTC = timezone.utc
+
+
+@pytest.fixture()
+def stub_check_all_dependencies(monkeypatch):
+    def fake_profile_config(symbol: str, meta: Dict[str, Any] | None) -> Dict[str, Any]:
+        return {}
+
+    def fake_profile_package(*args, **kwargs):
+        return ([], [], [])
+
+    def fake_detect_zones(*args, **kwargs):
+        return {
+            "zones": {
+                "fvg": [],
+                "fvl": [],
+                "ob": [],
+                "mb": [],
+                "bb": [],
+                "rb": [],
+                "pb": [],
+                "sr": [],
+                "profile_levels": [],
+            },
+            "meta": {},
+        }
+
+    def fake_liquidity(*args, **kwargs):
+        return {"eqh": [], "eql": [], "diagnostics": {"config": {}}}
+
+    def fake_multi_tf(candles: Sequence[Dict[str, Any]], *, symbol: str | None = None):
+        frame = {"candles": [dict(c) for c in candles]}
+        return {
+            "1m": frame,
+            "3m": frame,
+            "5m": frame,
+            "15m": frame,
+            "1h": frame,
+            "4h": frame,
+            "1d": frame,
+        }
+
+    def fake_aggregate(_candles: Sequence[Dict[str, Any]]):
+        return []
+
+    def fake_smc(*args, **kwargs):
+        return ([], {})
+
+    monkeypatch.setattr(check_all_datas, "resolve_profile_config", fake_profile_config)
+    monkeypatch.setattr(check_all_datas, "build_profile_package", fake_profile_package)
+    monkeypatch.setattr(check_all_datas, "detect_zones", fake_detect_zones)
+    monkeypatch.setattr(check_all_datas, "build_liquidity_snapshot", fake_liquidity)
+    monkeypatch.setattr(check_all_datas, "build_multi_timeframe_ohlcv", fake_multi_tf)
+    monkeypatch.setattr(check_all_datas, "aggregate_1m_to_1h", fake_aggregate)
+    monkeypatch.setattr(check_all_datas, "detect_smc_blocks", fake_smc)
+    monkeypatch.setattr(check_all_datas, "_build_expected_times", lambda *args, **kwargs: [])
+    monkeypatch.setattr(check_all_datas, "_summarise_missing_times", lambda *args, **kwargs: [])
+    yield
+
+
+def _snapshot_with_candles(candles: Sequence[Dict[str, Any]], entry_price: float) -> Dict[str, Any]:
+    return {
+        "symbol": "BTCUSDT",
+        "tf": "1m",
+        "frames": {"1m": {"tf": "1m", "candles": candles}},
+        "selection": {"start": candles[0]["t"], "end": candles[-1]["t"]},
+        "analysis": {"trade": {"entry_price": entry_price}},
+    }
+
+
+def test_last_price_prefers_minute_candle_over_analysis(stub_check_all_dependencies) -> None:
+    base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+    candles = []
+    for offset, close in enumerate((110.0, 116.0)):
+        moment = base + timedelta(minutes=offset)
+        candles.append(
+            {
+                "t": int(moment.timestamp() * 1000),
+                "o": 100.0 + offset,
+                "h": 120.0 + offset,
+                "l": 90.0 + offset,
+                "c": close,
+                "v": 5.0,
+            }
+        )
+
+    snapshot = _snapshot_with_candles(candles, entry_price=101.0)
+    now_dt = base + timedelta(minutes=2)
+
+    result = check_all_datas.build_check_all_datas(snapshot, now_utc=now_dt)
+
+    assert result is not None
+    meta = result["meta"]
+    assert meta["last_price"] == pytest.approx(116.0)
+    assert meta["last_tf"] == "1m"
+    assert meta.get("insufficient_reason") is None
+
+
+def test_snapshot_staleness_marks_meta(stub_check_all_dependencies) -> None:
+    base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+    stale_time = base
+    candles = [
+        {
+            "t": int(stale_time.timestamp() * 1000),
+            "o": 100.0,
+            "h": 110.0,
+            "l": 95.0,
+            "c": 105.0,
+            "v": 3.0,
+        }
+    ]
+    snapshot = _snapshot_with_candles(candles, entry_price=99.0)
+    now_dt = stale_time + timedelta(minutes=10)
+
+    result = check_all_datas.build_check_all_datas(snapshot, now_utc=now_dt)
+
+    assert result is not None
+    meta = result["meta"]
+    assert meta["last_price"] == pytest.approx(105.0)
+    assert meta["snapshot_age_sec"] >= 600
+    reason = meta.get("insufficient_reason")
+    assert isinstance(reason, str) and reason.startswith("stale_snapshot_")
+
+
+def test_last_price_updates_when_minute_candles_change(stub_check_all_dependencies) -> None:
+    base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+    first_candles = [
+        {
+            "t": int((base + timedelta(minutes=0)).timestamp() * 1000),
+            "o": 100.0,
+            "h": 110.0,
+            "l": 95.0,
+            "c": 105.0,
+            "v": 3.0,
+        },
+        {
+            "t": int((base + timedelta(minutes=1)).timestamp() * 1000),
+            "o": 105.0,
+            "h": 112.0,
+            "l": 100.0,
+            "c": 108.0,
+            "v": 3.5,
+        },
+    ]
+    snapshot = _snapshot_with_candles(first_candles, entry_price=100.0)
+    now_dt = base + timedelta(minutes=2)
+
+    initial = check_all_datas.build_check_all_datas(snapshot, now_utc=now_dt)
+    assert initial["meta"]["last_price"] == pytest.approx(108.0)
+
+    updated_candles = first_candles[:-1] + [
+        {
+            "t": int((base + timedelta(minutes=2)).timestamp() * 1000),
+            "o": 108.0,
+            "h": 118.0,
+            "l": 105.0,
+            "c": 123.0,
+            "v": 4.0,
+        }
+    ]
+    snapshot["frames"]["1m"]["candles"] = updated_candles
+    snapshot["selection"]["end"] = updated_candles[-1]["t"]
+
+    refreshed = check_all_datas.build_check_all_datas(snapshot, now_utc=base + timedelta(minutes=3))
+    assert refreshed["meta"]["last_price"] == pytest.approx(123.0)
+    assert refreshed["meta"]["last_tf"] == "1m"


### PR DESCRIPTION
## Summary
- derive the inspection last price from the freshest OHLCV candle with staleness checks and diagnostic logging
- restructure the check-all response to expose meta, availability counters, and missing fields while decoupling analysis entry prices
- update existing tests for the new payload shape and add dedicated coverage for last-price extraction and staleness

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de652030cc8324a10e9e964629e98b