### PR TITLE
Add cold backfill seeding and status for inspection payload

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta, timezone
 from math import ceil
 
 from fastapi import Body, FastAPI, HTTPException, Query, Request, Response
-from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -40,6 +39,7 @@ from ..services import (
     update_preset,
     apply_enrichment_to_payload,
     enrich_inspection_snapshot,
+    build_check_all_datas_async,
 )
 from ..services.zones import Config as ZonesConfig, detect_zones
 
@@ -56,6 +56,8 @@ from ..static_version import STATIC_VERSION
 from ..version import APP_VERSION
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LOGGER = logging.getLogger(__name__)
+CHECK_ALL_BUILD_TIMEOUT = 5.0
 
 
 
@@ -894,25 +896,47 @@ async def inspection_check_all(
         mode_value = "selection"
 
     collection_reference = now_override or datetime.now(timezone.utc)
+    has_now_override = now_override is not None
+    log_extra: Dict[str, Any] = {
+        "snapshot_id": target_snapshot.get("id"),
+        "mode": mode_value,
+        "selection_start": selection_start,
+        "selection_end": selection_end,
+        "hours": hours,
+        "has_now_override": has_now_override,
+    }
+    LOGGER.info("inspection_check_all:start", extra=log_extra)
 
     if mode_value == "summary":
         days = summary_days if summary_days and summary_days > 0 else 3
         window_hours = max(1, days * 24)
+        branch_log = dict(log_extra)
+        branch_log["window_hours"] = window_hours
         try:
-            payload = await run_in_threadpool(
-                build_check_all_datas,
+            payload = await build_check_all_datas_async(
                 target_snapshot,
                 now_utc=now_override,
                 window_hours=window_hours,
+                timeout=CHECK_ALL_BUILD_TIMEOUT,
             )
         except DataQualityError as exc:
+            LOGGER.warning(
+                "inspection_check_all:data_quality_error",
+                extra={**branch_log, "error": str(exc)},
+            )
             raise HTTPException(
                 status_code=400,
                 detail={"message": str(exc), "data_quality": exc.detail},
             ) from exc
         if payload is None:
+            LOGGER.info("inspection_check_all:finished", extra={**branch_log, "status": None})
             return Response(status_code=204)
         payload = _prepare_summary_payload(dict(payload))
+        status_value = payload.get("status") if isinstance(payload, Mapping) else None
+        LOGGER.info(
+            "inspection_check_all:finished",
+            extra={**branch_log, "status": status_value},
+        )
         set_last_collection_time(collection_reference)
         return JSONResponse(payload)
 
@@ -935,41 +959,66 @@ async def inspection_check_all(
             aligned_ms = (last_collection_ms // 60_000) * 60_000
             next_minute_ms = aligned_ms + 60_000
             window_start_override_ms = max(0, next_minute_ms)
+        branch_log = dict(log_extra)
+        branch_log["window_hours"] = window_hours
+        branch_log["window_start_override_ms"] = window_start_override_ms
         try:
-            payload = await run_in_threadpool(
-                build_check_all_datas,
+            payload = await build_check_all_datas_async(
                 target_snapshot,
                 now_utc=now_override,
                 window_hours=window_hours,
                 window_start_override_ms=window_start_override_ms,
                 strict_window=True,
+                timeout=CHECK_ALL_BUILD_TIMEOUT,
             )
         except DataQualityError as exc:
+            LOGGER.warning(
+                "inspection_check_all:data_quality_error",
+                extra={**branch_log, "error": str(exc)},
+            )
             raise HTTPException(
                 status_code=400,
                 detail={"message": str(exc), "data_quality": exc.detail},
             ) from exc
         if payload is None:
+            LOGGER.info("inspection_check_all:finished", extra={**branch_log, "status": None})
             return Response(status_code=204)
+        status_value = payload.get("status") if isinstance(payload, Mapping) else None
+        LOGGER.info(
+            "inspection_check_all:finished",
+            extra={**branch_log, "status": status_value},
+        )
         set_last_collection_time(collection_reference)
         return JSONResponse(payload)
 
+    branch_log = dict(log_extra)
     try:
-        payload = await run_in_threadpool(
-            build_check_all_datas,
+        payload = await build_check_all_datas_async(
             target_snapshot,
             now_utc=now_override,
             selection_start_ms=selection_start,
             selection_end_ms=selection_end,
             hours=hours,
+            timeout=CHECK_ALL_BUILD_TIMEOUT,
         )
     except DataQualityError as exc:
+        LOGGER.warning(
+            "inspection_check_all:data_quality_error",
+            extra={**branch_log, "error": str(exc)},
+        )
         raise HTTPException(
             status_code=400,
             detail={"message": str(exc), "data_quality": exc.detail},
         ) from exc
     if payload is None:
+        LOGGER.info("inspection_check_all:finished", extra={**branch_log, "status": None})
         return Response(status_code=204)
+
+    status_value = payload.get("status") if isinstance(payload, Mapping) else None
+    LOGGER.info(
+        "inspection_check_all:finished",
+        extra={**branch_log, "status": status_value},
+    )
 
     return JSONResponse(payload)
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 from math import ceil
 
 from fastapi import Body, FastAPI, HTTPException, Query, Request, Response
+from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -898,7 +899,8 @@ async def inspection_check_all(
         days = summary_days if summary_days and summary_days > 0 else 3
         window_hours = max(1, days * 24)
         try:
-            payload = build_check_all_datas(
+            payload = await run_in_threadpool(
+                build_check_all_datas,
                 target_snapshot,
                 now_utc=now_override,
                 window_hours=window_hours,
@@ -934,7 +936,8 @@ async def inspection_check_all(
             next_minute_ms = aligned_ms + 60_000
             window_start_override_ms = max(0, next_minute_ms)
         try:
-            payload = build_check_all_datas(
+            payload = await run_in_threadpool(
+                build_check_all_datas,
                 target_snapshot,
                 now_utc=now_override,
                 window_hours=window_hours,
@@ -952,7 +955,8 @@ async def inspection_check_all(
         return JSONResponse(payload)
 
     try:
-        payload = build_check_all_datas(
+        payload = await run_in_threadpool(
+            build_check_all_datas,
             target_snapshot,
             now_utc=now_override,
             selection_start_ms=selection_start,

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -40,6 +40,7 @@ from ..services import (
     apply_enrichment_to_payload,
     enrich_inspection_snapshot,
     build_check_all_datas_async,
+    build_inspection_error_payload,
 )
 from ..services.zones import Config as ZonesConfig, detect_zones
 
@@ -928,6 +929,18 @@ async def inspection_check_all(
                 status_code=400,
                 detail={"message": str(exc), "data_quality": exc.detail},
             ) from exc
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            LOGGER.exception(
+                "inspection_check_all:summary_failed",
+                extra={**branch_log, "error": str(exc)},
+            )
+            fallback = build_inspection_error_payload(
+                target_snapshot,
+                now_utc=now_override,
+                missing_fields=["ohlcv.1m"],
+                reason="invalid_timestamps",
+            )
+            return JSONResponse(fallback)
         if payload is None:
             LOGGER.info("inspection_check_all:finished", extra={**branch_log, "status": None})
             return Response(status_code=204)
@@ -980,6 +993,18 @@ async def inspection_check_all(
                 status_code=400,
                 detail={"message": str(exc), "data_quality": exc.detail},
             ) from exc
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            LOGGER.exception(
+                "inspection_check_all:summary_failed",
+                extra={**branch_log, "error": str(exc)},
+            )
+            fallback = build_inspection_error_payload(
+                target_snapshot,
+                now_utc=now_override,
+                missing_fields=["ohlcv.1m"],
+                reason="invalid_timestamps",
+            )
+            return JSONResponse(fallback)
         if payload is None:
             LOGGER.info("inspection_check_all:finished", extra={**branch_log, "status": None})
             return Response(status_code=204)
@@ -1010,6 +1035,18 @@ async def inspection_check_all(
             status_code=400,
             detail={"message": str(exc), "data_quality": exc.detail},
         ) from exc
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        LOGGER.exception(
+            "inspection_check_all:selection_failed",
+            extra={**branch_log, "error": str(exc)},
+        )
+        fallback = build_inspection_error_payload(
+            target_snapshot,
+            now_utc=now_override,
+            missing_fields=["ohlcv.1m"],
+            reason="invalid_timestamps",
+        )
+        return JSONResponse(fallback)
     if payload is None:
         LOGGER.info("inspection_check_all:finished", extra={**branch_log, "status": None})
         return Response(status_code=204)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,0 +1,13 @@
+"""Compatibility module to expose the FastAPI app under ``src.api.main``.
+
+Previous tooling and deployment scripts import ``src.api.main:app`` when
+starting the server. The project recently consolidated the app inside
+``src.api.app`` which broke those entrypoints. Importing and re-exporting
+``app`` here restores the old import path without duplicating the
+application setup.
+"""
+from __future__ import annotations
+
+from .app import app
+
+__all__ = ["app"]

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,7 +1,7 @@
 """Service layer exports for the chart backend."""
 
 from .binance import BINANCE_FAPI_REST
-from .check_all_datas import build_check_all_datas, DataQualityError
+from .check_all_datas import build_check_all_datas, build_check_all_datas_async, DataQualityError
 from .inspection import (
     build_inspection_payload,
     build_placeholder_snapshot,
@@ -56,6 +56,7 @@ __all__ = [
     "build_liquidity_snapshot",
     "build_check_all_datas",
     "build_placeholder_snapshot",
+    "build_check_all_datas_async",
     "DEFAULT_SYMBOL",
     "get_snapshot",
     "list_snapshots",

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,7 +1,12 @@
 """Service layer exports for the chart backend."""
 
 from .binance import BINANCE_FAPI_REST
-from .check_all_datas import build_check_all_datas, build_check_all_datas_async, DataQualityError
+from .check_all_datas import (
+    build_check_all_datas,
+    build_check_all_datas_async,
+    build_inspection_error_payload,
+    DataQualityError,
+)
 from .inspection import (
     build_inspection_payload,
     build_placeholder_snapshot,
@@ -57,6 +62,7 @@ __all__ = [
     "build_check_all_datas",
     "build_placeholder_snapshot",
     "build_check_all_datas_async",
+    "build_inspection_error_payload",
     "DEFAULT_SYMBOL",
     "get_snapshot",
     "list_snapshots",

--- a/src/services/check_all_datas.py
+++ b/src/services/check_all_datas.py
@@ -34,8 +34,10 @@ from .liquidity import (
 )
 from .presets import resolve_profile_config
 from .profile import build_profile_package
+from .ohlc_sanitizer import SanitizedCandles, sanitize_candles
 from .smc import SMCConfig, detect_smc_blocks
 from .zones import Config as ZonesConfig, detect_zones
+from .timeutils import safe_datetime_from_ms
 UTC = timezone.utc
 LOGGER = logging.getLogger(__name__)
 MS_IN_HOUR = 3_600_000
@@ -290,7 +292,9 @@ def _isoformat_utc(timestamp_ms: int) -> str:
     """Return a stable Z-suffixed ISO string for a millisecond timestamp."""
 
     clamped_ms = max(0, int(timestamp_ms))
-    dt = datetime.fromtimestamp(clamped_ms / 1000.0, tz=UTC)
+    dt = safe_datetime_from_ms(clamped_ms, UTC)
+    if dt is None:
+        return "1970-01-01T00:00:00Z"
     return dt.isoformat().replace("+00:00", "Z")
 
 
@@ -633,6 +637,32 @@ def _build_insufficient_payload(
         "missing_fields": sorted(missing_fields),
     }
     return round_floats(payload)
+
+
+def build_inspection_error_payload(
+    snapshot: Mapping[str, Any],
+    *,
+    now_utc: datetime | None = None,
+    missing_fields: Sequence[str] | None = None,
+    reason: str = "invalid_timestamps",
+) -> Dict[str, Any]:
+    """Return a deterministic insufficient-data payload for unexpected errors."""
+
+    context = _prepare_snapshot_context(snapshot, now_utc)
+    payload = _build_insufficient_payload(
+        symbol=context.symbol,
+        now=context.now,
+        stream_price=context.stream_price,
+        stream_ts=context.stream_ts,
+    )
+    if missing_fields:
+        existing = set(payload.get("missing_fields", []))
+        payload["missing_fields"] = sorted(existing.union(set(missing_fields)))
+    meta = payload.get("meta")
+    if isinstance(meta, dict):
+        meta["insufficient_reason"] = reason
+        meta["sanitized"] = True
+    return payload
 
 
 def _resolve_last_price(
@@ -1975,8 +2005,8 @@ def _build_volume_profile_stats(
     tick_size: float | None,
     value_area_pct: float = VALUE_AREA_PCT,
 ) -> Dict[str, Any]:
-    window_start_iso = datetime.fromtimestamp(start_ms / 1000.0, tz=UTC).isoformat()
-    window_end_iso = datetime.fromtimestamp(end_ms / 1000.0, tz=UTC).isoformat()
+    window_start_iso = _isoformat_utc(start_ms)
+    window_end_iso = _isoformat_utc(end_ms)
 
     if end_ms < start_ms:
         return {
@@ -2167,7 +2197,9 @@ def _build_prev_day_block(
 
 
 def _start_of_day_ms(timestamp_ms: int) -> int:
-    dt = datetime.fromtimestamp(timestamp_ms / 1000.0, tz=UTC)
+    dt = safe_datetime_from_ms(timestamp_ms, UTC)
+    if dt is None:
+        return 0
     start_dt = datetime(dt.year, dt.month, dt.day, tzinfo=UTC)
     return int(start_dt.timestamp() * 1000)
 
@@ -2178,7 +2210,9 @@ def _session_window(
     end_time: dtime,
 ) -> tuple[int, int, int]:
     anchor_aligned = _align_to_interval(anchor_ms, MINUTE_INTERVAL_MS)
-    anchor_dt = datetime.fromtimestamp(anchor_aligned / 1000.0, tz=UTC)
+    anchor_dt = safe_datetime_from_ms(anchor_aligned, UTC)
+    if anchor_dt is None:
+        anchor_dt = datetime(1970, 1, 1, tzinfo=UTC)
     day_start = datetime(anchor_dt.year, anchor_dt.month, anchor_dt.day, tzinfo=UTC)
     session_start_dt = datetime.combine(day_start.date(), start_time, tzinfo=UTC)
     session_end_dt = datetime.combine(day_start.date(), end_time, tzinfo=UTC)
@@ -2505,18 +2539,42 @@ async def build_check_all_datas(
     status = "ok"
 
     notes: List[str] = []
-    invalid_candles_count = 0
-    invalid_candle_stages: Counter[str] = Counter()
+    invalid_ts_total = 0
+    invalid_ohlc_total = 0
+    invalid_candle_stages: Dict[str, Dict[str, int]] = {}
+    sanitized_applied = False
+    sessions_empty_flag = False
+
+    def _record_invalid(stage: str, *, invalid_ts: int = 0, invalid_ohlc: int = 0) -> None:
+        nonlocal invalid_ts_total, invalid_ohlc_total
+        if invalid_ts == 0 and invalid_ohlc == 0:
+            return
+        entry = invalid_candle_stages.setdefault(stage, {"invalid_ts": 0, "invalid_ohlc": 0})
+        if invalid_ts:
+            entry["invalid_ts"] += int(invalid_ts)
+            invalid_ts_total += int(invalid_ts)
+        if invalid_ohlc:
+            entry["invalid_ohlc"] += int(invalid_ohlc)
+            invalid_ohlc_total += int(invalid_ohlc)
+
+    def _apply_sanitizer(stage: str, candles: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+        nonlocal sanitized_applied
+        sanitized_applied = True
+        result = sanitize_candles(candles, stage=stage)
+        _record_invalid(stage, invalid_ts=result.invalid_ts, invalid_ohlc=result.invalid_ohlc)
+        return result.candles
 
     def _register_invalid_candle(_ts: int, stage: str) -> None:
-        nonlocal invalid_candles_count
-        invalid_candles_count += 1
-        invalid_candle_stages[stage] += 1
+        _record_invalid(stage, invalid_ts=1)
 
     budget = _TimeBudget(_BUILD_TIMEOUT_SECONDS)
 
     context = _prepare_snapshot_context(snapshot, now_utc)
     frames = context.frames
+
+    for tf_key, candles in list(frames.items()):
+        stage_name = f"seed.{tf_key}"
+        frames[tf_key] = _apply_sanitizer(stage_name, candles)
     raw_meta = context.raw_meta
     symbol = context.symbol
     now_dt = context.now
@@ -2562,6 +2620,7 @@ async def build_check_all_datas(
         window_end_ms=window_end_guess,
         window_hours=base_window_hours,
     )
+    frames["1m"] = _apply_sanitizer("rest.1m", frames.get("1m", []))
 
     minute_seed = frames.get("1m", [])
     if minute_seed:
@@ -2589,6 +2648,7 @@ async def build_check_all_datas(
             window_end_ms=window_end_guess,
             window_hours=base_window_hours,
         )
+        frames[primary_key] = _apply_sanitizer(f"rest.{primary_key}", frames.get(primary_key, []))
 
     primary_candles = frames.get(primary_key, [])
     if not primary_candles:
@@ -2602,6 +2662,7 @@ async def build_check_all_datas(
     frames["1m"] = minute_candles
 
     profile_config = resolve_profile_config(symbol, raw_meta)
+    profile_meta: Dict[str, Any] = {}
     sessions = list(VWAP_TPO_SESSIONS)
     profile_tpo: List[Dict[str, Any]] = []
     profile_flat: List[Dict[str, float]] = []
@@ -2664,8 +2725,10 @@ async def build_check_all_datas(
             cache_token=cache_token,
             tf_key=target_tf_key,
             invalid_ts_handler=_register_invalid_candle,
+            meta_out=profile_meta,
         )
         profile_level_map = _build_profile_level_map(profile_tpo)
+        sessions_empty_flag = bool(profile_meta.get("sessions_empty"))
 
     snapshot_selection = snapshot.get("selection") if isinstance(snapshot.get("selection"), Mapping) else None
     selection_start = selection_start_ms or _safe_int(snapshot_selection.get("start")) if snapshot_selection else None
@@ -2756,6 +2819,9 @@ async def build_check_all_datas(
                 window_end_ms,
                 time_gaps,
                 budget=budget,
+            )
+            downloaded_minutes = _apply_sanitizer(
+                "rest.1m.download", downloaded_minutes
             )
         except BinanceDownloadError as exc:
             detail = {
@@ -3022,7 +3088,7 @@ async def build_check_all_datas(
     liquidity_config = raw_meta.get("liquidity") if isinstance(raw_meta, Mapping) else None
 
     reference_ts = window_end_ms + MINUTE_INTERVAL_MS
-    reference_dt = datetime.fromtimestamp(reference_ts / 1000.0, tz=UTC)
+    reference_iso = _isoformat_utc(reference_ts)
     detailed_start_ts = window_start_ms
 
     movement_anchor_ts = detailed_start_ts
@@ -3030,6 +3096,10 @@ async def build_check_all_datas(
     movement_end_ts = max(selection_start, movement_anchor_ts)
     if movement_end_ts > window_end_ms:
         movement_end_ts = window_end_ms
+
+    detailed_start_iso = _isoformat_utc(detailed_start_ts)
+    movement_start_iso = _isoformat_utc(movement_start_ts)
+    movement_end_iso = _isoformat_utc(movement_end_ts)
 
     latest_minute_candle = minute_window_index.get(window_end_ms)
     latest_primary_candle = None
@@ -3048,12 +3118,6 @@ async def build_check_all_datas(
         latest_candle_ts = base_candles[-1]["t"]
     if latest_candle_ts is None:
         latest_candle_ts = window_end_ms
-    latest_candle_dt = datetime.fromtimestamp(latest_candle_ts / 1000.0, tz=UTC)
-
-    detailed_start_dt = datetime.fromtimestamp(detailed_start_ts / 1000.0, tz=UTC)
-    movement_start_dt = datetime.fromtimestamp(movement_start_ts / 1000.0, tz=UTC)
-    movement_end_dt = datetime.fromtimestamp(movement_end_ts / 1000.0, tz=UTC)
-
     detailed_frames: Dict[str, Any] = {}
     for tf_key, candles in frames.items():
         filtered = _filter_candles(candles, start_ms=detailed_start_ts, end_ms=reference_ts)
@@ -3078,8 +3142,8 @@ async def build_check_all_datas(
     detailed_section = {
         "hours": hours_window,
         "range": {
-            "start_utc": detailed_start_dt.isoformat(),
-            "end_utc": reference_dt.isoformat(),
+            "start_utc": detailed_start_iso,
+            "end_utc": reference_iso,
         },
         "frames": detailed_frames,
         "indicators": {
@@ -3108,8 +3172,8 @@ async def build_check_all_datas(
         delta_series = _build_delta_series(filtered)
         movement_frames[tf_key] = {
             "summary": _summarise(filtered),
-            "first_candle_utc": datetime.fromtimestamp(filtered[0]["t"] / 1000.0, tz=UTC).isoformat(),
-            "last_candle_utc": datetime.fromtimestamp(filtered[-1]["t"] / 1000.0, tz=UTC).isoformat(),
+            "first_candle_utc": _isoformat_utc(filtered[0]["t"]),
+            "last_candle_utc": _isoformat_utc(filtered[-1]["t"]),
         }
         delta_summaries[tf_key] = _summarise_delta_series(delta_series)
         vwap_summaries[tf_key] = {
@@ -3139,8 +3203,8 @@ async def build_check_all_datas(
     movement_section = {
         "days": movement_days,
         "range": {
-            "start_utc": movement_start_dt.isoformat(),
-            "end_utc": movement_end_dt.isoformat(),
+            "start_utc": movement_start_iso,
+            "end_utc": movement_end_iso,
         },
         "frames": movement_frames,
         "indicators": {
@@ -3980,23 +4044,40 @@ async def build_check_all_datas(
     if last_price_diag.get("mismatch"):
         meta_block["stream_vs_ohlcv_mismatch"] = True
 
-    meta_block["invalid_candles_count"] = invalid_candles_count
-    meta_block["invalid_candle_stages"] = dict(
-        sorted(invalid_candle_stages.items())
-    ) if invalid_candle_stages else {}
+    invalid_total = invalid_ts_total + invalid_ohlc_total
+    meta_block["invalid_candles_count"] = invalid_total
+    meta_block["invalid_ts_count"] = invalid_ts_total
+    meta_block["invalid_ohlc_count"] = invalid_ohlc_total
+    meta_block["sanitized"] = sanitized_applied
+    meta_block["sessions_empty"] = sessions_empty_flag
 
-    if invalid_candles_count:
-        stage_summary = ", ".join(
-            f"{stage}:{count}" for stage, count in sorted(invalid_candle_stages.items())
-        )
-        if stage_summary:
+    stage_breakdown: Dict[str, Dict[str, int]] = {}
+    for stage, counts in sorted(invalid_candle_stages.items()):
+        filtered_counts = {key: value for key, value in counts.items() if value}
+        if filtered_counts:
+            stage_breakdown[stage] = filtered_counts
+    meta_block["invalid_candle_stages"] = stage_breakdown
+
+    if invalid_ts_total:
+        if stage_breakdown:
+            ts_stages = {stage: counts.get("invalid_ts", 0) for stage, counts in stage_breakdown.items()}
+            ts_summary = ", ".join(
+                f"{stage}:{count}" for stage, count in ts_stages.items() if count
+            )
+        else:
+            ts_summary = ""
+        if ts_summary:
             notes.append(
-                f"Filtered {invalid_candles_count} candles with invalid timestamps ({stage_summary})"
+                f"Filtered {invalid_ts_total} candles with invalid timestamps ({ts_summary})"
             )
         else:
             notes.append(
-                f"Filtered {invalid_candles_count} candles with invalid timestamps"
+                f"Filtered {invalid_ts_total} candles with invalid timestamps"
             )
+    if invalid_ohlc_total:
+        notes.append(
+            f"Filtered {invalid_ohlc_total} candles with invalid OHLC ranges"
+        )
 
     final_payload = {
         "status": status,

--- a/src/services/check_all_datas.py
+++ b/src/services/check_all_datas.py
@@ -6,7 +6,7 @@ import math
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone, time as dtime
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple, Set
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple, Set
 
 import httpx
 
@@ -51,6 +51,7 @@ try:
         TIMEFRAME_TO_MS,
         aggregate_1m_to_1h,
         build_multi_timeframe_ohlcv,
+        fetch_ohlcv_sync,
         resample_ohlcv,
     )
 except ImportError:  # pragma: no cover - circular import guard
@@ -65,6 +66,9 @@ except ImportError:  # pragma: no cover - circular import guard
     def build_multi_timeframe_ohlcv(*args, **kwargs):  # type: ignore[override]
         raise ImportError("build_multi_timeframe_ohlcv is unavailable")
 
+    def fetch_ohlcv_sync(*args, **kwargs):  # type: ignore[override]
+        raise ImportError("fetch_ohlcv_sync is unavailable")
+
 MINUTE_INTERVAL_MS = TIMEFRAME_TO_MS.get("1m", MS_IN_HOUR // 60)
 
 VWAP_TPO_SESSIONS: Tuple[Tuple[str, dtime, dtime], ...] = (
@@ -75,6 +79,25 @@ VWAP_TPO_SESSIONS: Tuple[Tuple[str, dtime, dtime], ...] = (
 
 _RETRYABLE_STATUS = {418, 429, 500, 502, 503, 504}
 _MAX_RETRIES = 5
+
+_EXPECTED_OHLCV_TFS: Tuple[str, ...] = ("1m", "3m", "5m", "15m", "1h", "4h", "1d")
+_EXPECTED_ORDERFLOW_TFS: Tuple[str, ...] = ("15m", "1h")
+_EXPECTED_ORDERFLOW_METRICS: Tuple[str, ...] = ("footprint", "delta", "cvd")
+_EXPECTED_ZONE_KEYS: Tuple[str, ...] = (
+    "fvg",
+    "fvl",
+    "ob",
+    "mb",
+    "bb",
+    "rb",
+    "pb",
+    "sr",
+    "profile_levels",
+)
+
+_COLD_BACKFILL_MIN_REQUIRED: Dict[str, int] = {
+    tf: 1 for tf in _EXPECTED_OHLCV_TFS
+}
 
 class DataQualityError(RuntimeError):
     """Raised when the inspected snapshot fails deterministic data checks."""
@@ -200,6 +223,238 @@ def _deduplicate_sorted(
 
     ordered_times = sorted(seen)
     return [seen[ts] for ts in ordered_times]
+
+
+def _normalise_external_candles(
+    payload: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None,
+) -> List[Dict[str, Any]]:
+    """Normalise external candle payloads into the internal shape."""
+
+    if payload is None:
+        return []
+
+    if isinstance(payload, Mapping):
+        raw_candles = payload.get("candles")
+        if not isinstance(raw_candles, Sequence):
+            return []
+        source: Sequence[Mapping[str, Any]] = raw_candles  # type: ignore[assignment]
+    elif isinstance(payload, Sequence):
+        source = [item for item in payload if isinstance(item, Mapping)]  # type: ignore[list-item]
+    else:
+        return []
+
+    normalised: List[Dict[str, Any]] = []
+    for item in source:
+        ts = _safe_int(item.get("t"))
+        if ts is None:
+            continue
+        normalised.append(
+            {
+                "t": ts,
+                "o": _coerce_float(item.get("o")),
+                "h": _coerce_float(item.get("h")),
+                "l": _coerce_float(item.get("l")),
+                "c": _coerce_float(item.get("c")),
+                "v": _coerce_float(item.get("v")),
+            }
+        )
+
+    normalised.sort(key=lambda candle: candle["t"])
+    return normalised
+
+
+def _merge_candle_collections(
+    existing: Sequence[Mapping[str, Any]],
+    incoming: Sequence[Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Merge two candle collections preferring values from the existing set."""
+
+    combined: List[Mapping[str, Any]] = []
+    if incoming:
+        combined.extend(incoming)
+    if existing:
+        combined.extend(existing)
+    return _deduplicate_sorted(combined)
+
+
+def _resolve_window_end_ms(
+    frames: Mapping[str, Sequence[Mapping[str, Any]]],
+    *,
+    now_ms: int,
+    selection_end_ms: int | None,
+    stream_ts: int | None,
+) -> int:
+    """Resolve a best-effort window end timestamp based on available hints."""
+
+    candidates: List[int] = [now_ms]
+    if selection_end_ms is not None:
+        candidates.append(selection_end_ms)
+    if stream_ts is not None:
+        candidates.append(stream_ts)
+
+    for candles in frames.values():
+        if not candles:
+            continue
+        last_ts = _safe_int(candles[-1].get("t"))
+        if last_ts is not None:
+            candidates.append(last_ts)
+
+    return max(candidates) if candidates else now_ms
+
+
+def _backfill_timeframe_with_rest(
+    frames: MutableMapping[str, List[MutableMapping[str, Any]]],
+    *,
+    symbol: str,
+    timeframe: str,
+    window_end_ms: int,
+    window_hours: int,
+    fetcher: Callable[..., Mapping[str, Any]] | None = None,
+    minimum_required: int | None = None,
+) -> bool:
+    """Ensure the requested timeframe has at least the required candles."""
+
+    interval_ms = TIMEFRAME_TO_MS.get(timeframe)
+    if interval_ms is None:
+        return False
+
+    if minimum_required is None:
+        minimum_required = _COLD_BACKFILL_MIN_REQUIRED.get(timeframe, 1)
+    minimum_required = max(1, int(minimum_required))
+
+    existing = frames.get(timeframe, [])
+    window_start_ms = max(0, window_end_ms - max(1, window_hours) * MS_IN_HOUR)
+
+    available = 0
+    for candle in existing:
+        ts = _safe_int(candle.get("t"))
+        if ts is None:
+            continue
+        if window_start_ms <= ts <= window_end_ms:
+            available += 1
+            if available >= minimum_required:
+                return False
+
+    fetch_callable = fetcher or fetch_ohlcv_sync
+    try:
+        fetched_payload = fetch_callable(symbol, timeframe, hours=max(1, window_hours))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        LOGGER.warning(
+            "Cold backfill request failed",
+            exc_info=exc,
+            extra={
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "window_hours": window_hours,
+            },
+        )
+        return False
+
+    fetched_candles = _normalise_external_candles(fetched_payload)
+    if not fetched_candles:
+        return False
+
+    merged = _merge_candle_collections(existing, fetched_candles)
+    frames[timeframe] = [dict(candle) for candle in merged]
+    return True
+
+
+def _build_insufficient_payload(
+    *,
+    symbol: str,
+    now: datetime,
+    stream_price: float | None,
+    stream_ts: int | None,
+) -> Dict[str, Any]:
+    """Return a deterministic payload when cold backfill could not seed data."""
+
+    frames_stub: Dict[str, Sequence[Mapping[str, Any]]] = {
+        tf: [] for tf in _EXPECTED_OHLCV_TFS
+    }
+    (
+        last_price,
+        last_iso,
+        last_tf,
+        age_sec,
+        _,
+        price_source,
+        _diagnostics,
+    ) = _resolve_last_price(
+        frames_stub,
+        now=now,
+        stream_price=stream_price,
+        stream_ts=stream_ts,
+        tick_size=None,
+    )
+
+    meta_block: Dict[str, Any] = {
+        "symbol": symbol,
+        "tz": "Europe/Berlin",
+        "last_price": last_price,
+        "last_ts_utc": last_iso,
+        "last_tf": last_tf,
+        "last_price_source": price_source,
+        "insufficient_reason": "stale_or_unseeded_buffers",
+        "stale": True,
+    }
+    if age_sec is not None:
+        meta_block["snapshot_age_sec"] = age_sec
+
+    data_payload = {
+        "symbol": symbol,
+        "ohlcv": {tf: {"candles": []} for tf in _EXPECTED_OHLCV_TFS},
+        "orderflow": {tf: {"per_bar": []} for tf in _EXPECTED_ORDERFLOW_TFS},
+        "vwap_tpo": {
+            "daily": {},
+            "sessions": {session: {} for session in ("asia", "london", "ny")},
+        },
+        "tpo": {"composite_day": {}},
+        "prev_day": {},
+        "zones": {key: [] for key in _EXPECTED_ZONE_KEYS},
+        "liquidity": {"eqh": [], "eql": []},
+        "risk_prefs": {"rr_min": 2.5, "risk_per_trade_pct": 1.0},
+        "context": {"globalBias": "neutral", "narrative": "", "openOppositeZones": False},
+    }
+
+    availability_payload = {
+        "ohlcv": {tf: {"candles": 0, "has_data": False} for tf in _EXPECTED_OHLCV_TFS},
+        "vwap_sessions": {
+            session: {
+                "present": False,
+                "metrics": {
+                    metric: False
+                    for metric in ("poc", "vah", "val", "ib_high", "ib_low")
+                },
+            }
+            for session in ("asia", "london", "ny")
+        },
+        "zones": {key: {"count": 0} for key in _EXPECTED_ZONE_KEYS},
+        "orderflow": {
+            "timeframes": {
+                tf: {"bars": 0, "has_data": False} for tf in _EXPECTED_ORDERFLOW_TFS
+            },
+            "metrics": {metric: False for metric in _EXPECTED_ORDERFLOW_METRICS},
+        },
+    }
+
+    missing_fields: Set[str] = set()
+    missing_fields.update(f"ohlcv.{tf}" for tf in _EXPECTED_OHLCV_TFS)
+    for session in ("asia", "london", "ny"):
+        missing_fields.add(f"vwap_tpo.sessions.{session}")
+        for metric in ("poc", "vah", "val", "ib_high", "ib_low"):
+            missing_fields.add(f"vwap_tpo.sessions.{session}.{metric}")
+    missing_fields.update(f"zones.{key}" for key in _EXPECTED_ZONE_KEYS)
+    missing_fields.update(f"orderflow.{tf}" for tf in _EXPECTED_ORDERFLOW_TFS)
+    missing_fields.update(f"orderflow.{metric}" for metric in _EXPECTED_ORDERFLOW_METRICS)
+
+    payload = {
+        "status": "insufficient_data",
+        "meta": meta_block,
+        "data": data_payload,
+        "availability": availability_payload,
+        "missing_fields": sorted(missing_fields),
+    }
+    return round_floats(payload)
 
 
 def _resolve_last_price(
@@ -2016,27 +2271,17 @@ def build_check_all_datas(
 ) -> Dict[str, Any] | None:
     """Create an enriched payload for the snapshot health endpoint."""
 
+    status = "ok"
+
     frames = _normalise_frames(snapshot)
-    if not frames:
-        return None
-
-    primary_key = _primary_frame_key(snapshot, frames)
-    if not primary_key:
-        return None
-
-    primary_candles = frames.get(primary_key, [])
-    if not primary_candles:
-        return None
-
-    # Drop unused granularities to keep the payload focused on the requested set.
-    frames.pop("3m", None)
-    frames.pop("5m", None)
-
-    minute_candles = _deduplicate_sorted(frames.get("1m", []))
-    frames["1m"] = minute_candles
-
-    symbol = str(snapshot.get("symbol") or snapshot.get("pair") or "UNKNOWN").upper()
     raw_meta = snapshot.get("meta") if isinstance(snapshot.get("meta"), Mapping) else None
+    symbol = str(snapshot.get("symbol") or snapshot.get("pair") or "UNKNOWN").upper()
+
+    if now_utc is None:
+        now_dt = datetime.now(UTC)
+    else:
+        now_dt = now_utc.astimezone(UTC)
+    now_ms = int(now_dt.timestamp() * 1000)
 
     stream_price: float | None = None
     stream_ts: int | None = None
@@ -2060,6 +2305,76 @@ def build_check_all_datas(
         stream_price = price
         stream_ts = ts
         break
+
+    if selection_end_ms is None:
+        selection_payload = snapshot.get("selection")
+        if isinstance(selection_payload, Mapping):
+            selection_end_candidate = _safe_int(selection_payload.get("end"))
+            if selection_end_candidate is not None:
+                selection_end_ms = selection_end_candidate
+
+    if not frames:
+        frames = {}
+
+    base_window_hours = window_hours if window_hours is not None else hours
+    if base_window_hours is None or base_window_hours <= 0:
+        base_window_hours = 4
+    base_window_hours = int(base_window_hours)
+
+    window_end_guess = _resolve_window_end_ms(
+        frames,
+        now_ms=now_ms,
+        selection_end_ms=selection_end_ms,
+        stream_ts=stream_ts,
+    )
+
+    _backfill_timeframe_with_rest(
+        frames,
+        symbol=symbol,
+        timeframe="1m",
+        window_end_ms=window_end_guess,
+        window_hours=base_window_hours,
+    )
+
+    minute_seed = frames.get("1m", [])
+    if minute_seed:
+        frames["1m"] = _deduplicate_sorted(minute_seed)
+
+    primary_key = _primary_frame_key(snapshot, frames)
+    if not primary_key and "1m" in frames:
+        primary_key = "1m"
+    if not primary_key:
+        return _build_insufficient_payload(
+            symbol=symbol,
+            now=now_dt,
+            stream_price=stream_price,
+            stream_ts=stream_ts,
+        )
+
+    if not frames.get(primary_key):
+        _backfill_timeframe_with_rest(
+            frames,
+            symbol=symbol,
+            timeframe=primary_key,
+            window_end_ms=window_end_guess,
+            window_hours=base_window_hours,
+        )
+
+    primary_candles = frames.get(primary_key, [])
+    if not primary_candles:
+        return _build_insufficient_payload(
+            symbol=symbol,
+            now=now_dt,
+            stream_price=stream_price,
+            stream_ts=stream_ts,
+        )
+
+    # Drop unused granularities to keep the payload focused on the requested set.
+    frames.pop("3m", None)
+    frames.pop("5m", None)
+
+    minute_candles = _deduplicate_sorted(frames.get("1m", []))
+    frames["1m"] = minute_candles
 
     profile_config = resolve_profile_config(symbol, raw_meta)
     sessions = list(VWAP_TPO_SESSIONS)
@@ -2161,7 +2476,12 @@ def build_check_all_datas(
         window_end_ms = primary_candles[-1]["t"] + max(primary_interval - MINUTE_INTERVAL_MS, 0)
 
     if window_end_ms is None:
-        return None
+        return _build_insufficient_payload(
+            symbol=symbol,
+            now=now_dt,
+            stream_price=stream_price,
+            stream_ts=stream_ts,
+        )
 
     window_end_ms = max(0, _align_to_interval(window_end_ms, MINUTE_INTERVAL_MS))
 
@@ -3408,6 +3728,7 @@ def build_check_all_datas(
         meta_block["stream_vs_ohlcv_mismatch"] = True
 
     final_payload = {
+        "status": status,
         "meta": meta_block,
         "data": data_payload,
         "availability": availability,

--- a/src/services/check_all_datas.py
+++ b/src/services/check_all_datas.py
@@ -80,6 +80,8 @@ VWAP_TPO_SESSIONS: Tuple[Tuple[str, dtime, dtime], ...] = (
 _RETRYABLE_STATUS = {418, 429, 500, 502, 503, 504}
 _MAX_RETRIES = 5
 
+_BUILD_TIMEOUT_SECONDS = 12.0
+
 _EXPECTED_OHLCV_TFS: Tuple[str, ...] = ("1m", "3m", "5m", "15m", "1h", "4h", "1d")
 _EXPECTED_ORDERFLOW_TFS: Tuple[str, ...] = ("15m", "1h")
 _EXPECTED_ORDERFLOW_METRICS: Tuple[str, ...] = ("footprint", "delta", "cvd")
@@ -113,6 +115,37 @@ class BinanceDownloadError(RuntimeError):
     def __init__(self, downloaded: int, message: str):
         super().__init__(message)
         self.downloaded = int(downloaded)
+
+
+class _TimeBudgetExceeded(RuntimeError):
+    """Raised when the snapshot build exceeds the allocated time budget."""
+
+    def __init__(self, stage: str):
+        self.stage = stage
+        super().__init__(f"Time budget exceeded while {stage}")
+
+
+class _TimeBudget:
+    """Helper for enforcing a soft timeout while building the snapshot."""
+
+    __slots__ = ("deadline",)
+
+    def __init__(self, seconds: float | None):
+        if seconds is None or seconds <= 0:
+            self.deadline = None
+        else:
+            self.deadline = time.monotonic() + seconds
+
+    def remaining(self) -> float | None:
+        if self.deadline is None:
+            return None
+        return self.deadline - time.monotonic()
+
+    def raise_if_exceeded(self, stage: str) -> None:
+        if self.deadline is None:
+            return
+        if time.monotonic() >= self.deadline:
+            raise _TimeBudgetExceeded(stage)
 
 
 def _isoformat_utc(timestamp_ms: int) -> str:
@@ -643,6 +676,7 @@ def _request_binance_minutes(
     end_ms: int,
     *,
     limit: int,
+    budget: _TimeBudget | None = None,
 ) -> List[Sequence[object]]:
     params = {
         "symbol": symbol.upper(),
@@ -654,6 +688,8 @@ def _request_binance_minutes(
 
     delay = 0.5
     for attempt in range(_MAX_RETRIES):
+        if budget is not None:
+            budget.raise_if_exceeded("request_binance_minutes")
         try:
             response = client.get(BINANCE_FAPI_REST, params=params)
             response.raise_for_status()
@@ -664,13 +700,27 @@ def _request_binance_minutes(
         except httpx.HTTPStatusError as exc:
             status = exc.response.status_code
             if status in _RETRYABLE_STATUS and attempt < _MAX_RETRIES - 1:
-                time.sleep(delay)
+                if budget is not None:
+                    budget.raise_if_exceeded("request_binance_minutes_backoff")
+                    remaining = budget.remaining()
+                    if remaining is not None and remaining <= 0:
+                        raise
+                    time.sleep(min(delay, max(0.0, remaining)))
+                else:
+                    time.sleep(delay)
                 delay *= 2
                 continue
             raise
         except httpx.RequestError:
             if attempt < _MAX_RETRIES - 1:
-                time.sleep(delay)
+                if budget is not None:
+                    budget.raise_if_exceeded("request_binance_minutes_retry")
+                    remaining = budget.remaining()
+                    if remaining is not None and remaining <= 0:
+                        raise
+                    time.sleep(min(delay, max(0.0, remaining)))
+                else:
+                    time.sleep(delay)
                 delay *= 2
                 continue
             raise
@@ -682,6 +732,8 @@ def _download_missing_minutes(
     start_ms: int,
     end_ms: int,
     gaps: Sequence[Mapping[str, int]],
+    *,
+    budget: _TimeBudget | None = None,
 ) -> List[Dict[str, Any]]:
     if not gaps:
         return []
@@ -690,12 +742,16 @@ def _download_missing_minutes(
     downloaded = 0
 
     try:
-        with httpx.Client(timeout=15.0) as client:
+        with httpx.Client(timeout=httpx.Timeout(6.0, connect=3.0)) as client:
             for gap in gaps:
+                if budget is not None:
+                    budget.raise_if_exceeded("download_missing_minutes_gap")
                 gap_start = int(gap["from"])
                 gap_end = int(gap["to"])
                 cursor = gap_start
                 while cursor <= gap_end:
+                    if budget is not None:
+                        budget.raise_if_exceeded("download_missing_minutes_cursor")
                     chunk_end = min(
                         gap_end,
                         cursor + (1000 - 1) * MINUTE_INTERVAL_MS,
@@ -707,6 +763,7 @@ def _download_missing_minutes(
                         cursor,
                         request_end,
                         limit=1000,
+                        budget=budget,
                     )
                     if not raw_rows:
                         break
@@ -732,6 +789,34 @@ def _download_missing_minutes(
         raise BinanceDownloadError(downloaded, str(exc)) from exc
 
     return fetched
+
+
+def _call_download_missing_minutes(
+    symbol: str,
+    start_ms: int,
+    end_ms: int,
+    gaps: Sequence[Mapping[str, int]],
+    *,
+    budget: _TimeBudget | None,
+) -> List[Dict[str, Any]]:
+    """Invoke `_download_missing_minutes` while tolerating legacy stubs without budget."""
+
+    if budget is None:
+        return _download_missing_minutes(symbol, start_ms, end_ms, gaps)
+
+    try:
+        return _download_missing_minutes(
+            symbol,
+            start_ms,
+            end_ms,
+            gaps,
+            budget=budget,
+        )
+    except TypeError as exc:
+        message = str(exc)
+        if "unexpected keyword argument" not in message or "budget" not in message:
+            raise
+        return _download_missing_minutes(symbol, start_ms, end_ms, gaps)
 
 
 def _aggregate_from_minutes(
@@ -2273,6 +2358,8 @@ def build_check_all_datas(
 
     status = "ok"
 
+    budget = _TimeBudget(_BUILD_TIMEOUT_SECONDS)
+
     frames = _normalise_frames(snapshot)
     raw_meta = snapshot.get("meta") if isinstance(snapshot.get("meta"), Mapping) else None
     symbol = str(snapshot.get("symbol") or snapshot.get("pair") or "UNKNOWN").upper()
@@ -2328,6 +2415,20 @@ def build_check_all_datas(
         stream_ts=stream_ts,
     )
 
+    try:
+        budget.raise_if_exceeded("seed_1m_backfill")
+    except _TimeBudgetExceeded as exc:
+        LOGGER.warning(
+            "Time budget exceeded before seeding minute frame",
+            extra={"stage": exc.stage, "symbol": symbol},
+        )
+        return _build_insufficient_payload(
+            symbol=symbol,
+            now=now_dt,
+            stream_price=stream_price,
+            stream_ts=stream_ts,
+        )
+
     _backfill_timeframe_with_rest(
         frames,
         symbol=symbol,
@@ -2352,6 +2453,19 @@ def build_check_all_datas(
         )
 
     if not frames.get(primary_key):
+        try:
+            budget.raise_if_exceeded("seed_primary_backfill")
+        except _TimeBudgetExceeded as exc:
+            LOGGER.warning(
+                "Time budget exceeded before seeding primary frame",
+                extra={"stage": exc.stage, "symbol": symbol, "primary_key": primary_key},
+            )
+            return _build_insufficient_payload(
+                symbol=symbol,
+                now=now_dt,
+                stream_price=stream_price,
+                stream_ts=stream_ts,
+            )
         _backfill_timeframe_with_rest(
             frames,
             symbol=symbol,
@@ -2536,11 +2650,13 @@ def build_check_all_datas(
     fetched_unique = 0
     if time_gaps:
         try:
-            downloaded_minutes = _download_missing_minutes(
+            budget.raise_if_exceeded("download_missing_minutes_start")
+            downloaded_minutes = _call_download_missing_minutes(
                 symbol,
                 window_start_ms,
                 window_end_ms,
                 time_gaps,
+                budget=budget,
             )
         except BinanceDownloadError as exc:
             detail = {
@@ -2555,6 +2671,23 @@ def build_check_all_datas(
                 "downloaded": exc.downloaded,
             }
             raise DataQualityError(detail) from exc
+        except _TimeBudgetExceeded as exc:
+            LOGGER.warning(
+                "Time budget exceeded while downloading missing 1m candles",
+                extra={
+                    "stage": exc.stage,
+                    "symbol": symbol,
+                    "window_start_ms": window_start_ms,
+                    "window_end_ms": window_end_ms,
+                    "time_gaps": time_gaps,
+                },
+            )
+            return _build_insufficient_payload(
+                symbol=symbol,
+                now=now_dt,
+                stream_price=stream_price,
+                stream_ts=stream_ts,
+            )
         for candle in downloaded_minutes:
             ts = candle["t"]
             if ts < window_start_ms or ts > window_end_ms:
@@ -2582,6 +2715,20 @@ def build_check_all_datas(
 
     frames["1m"] = [minute_index_all[ts] for ts in sorted(minute_index_all)]
     minute_candles = frames["1m"]
+
+    try:
+        budget.raise_if_exceeded("zones_preparation")
+    except _TimeBudgetExceeded as exc:
+        LOGGER.warning(
+            "Time budget exceeded before zones preparation",
+            extra={"stage": exc.stage, "symbol": symbol},
+        )
+        return _build_insufficient_payload(
+            symbol=symbol,
+            now=now_dt,
+            stream_price=stream_price,
+            stream_ts=stream_ts,
+        )
 
     zones_window_hours = max(1, hours_window)
     if not strict_window:
@@ -2623,11 +2770,13 @@ def build_check_all_datas(
     zone_history_gaps = _summarise_missing_times(zone_expected_minutes, minute_index_all)
     if zone_history_gaps:
         try:
-            zone_downloaded_minutes = _download_missing_minutes(
+            budget.raise_if_exceeded("zones_history_backfill_start")
+            zone_downloaded_minutes = _call_download_missing_minutes(
                 symbol,
                 zones_history_start_ms,
                 window_end_ms,
                 zone_history_gaps,
+                budget=budget,
             )
         except BinanceDownloadError as exc:
             detail = {
@@ -2639,6 +2788,23 @@ def build_check_all_datas(
                 "time_gaps": zone_history_gaps,
             }
             raise DataQualityError(detail) from exc
+        except _TimeBudgetExceeded as exc:
+            LOGGER.warning(
+                "Time budget exceeded while seeding zone history",
+                extra={
+                    "stage": exc.stage,
+                    "symbol": symbol,
+                    "zones_history_start_ms": zones_history_start_ms,
+                    "window_end_ms": window_end_ms,
+                    "time_gaps": zone_history_gaps,
+                },
+            )
+            return _build_insufficient_payload(
+                symbol=symbol,
+                now=now_dt,
+                stream_price=stream_price,
+                stream_ts=stream_ts,
+            )
         for candle in zone_downloaded_minutes:
             ts = candle["t"]
             if ts < zones_history_start_ms or ts > window_end_ms:

--- a/src/services/check_all_datas.py
+++ b/src/services/check_all_datas.py
@@ -7,8 +7,19 @@ import math
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone, time as dtime
-from functools import partial
-from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple, Set
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Sequence,
+    Tuple,
+    Set,
+)
 
 import httpx
 
@@ -53,6 +64,7 @@ try:
         TIMEFRAME_TO_MS,
         aggregate_1m_to_1h,
         build_multi_timeframe_ohlcv,
+        fetch_ohlcv,
         fetch_ohlcv_sync,
         resample_ohlcv,
     )
@@ -67,6 +79,9 @@ except ImportError:  # pragma: no cover - circular import guard
 
     def build_multi_timeframe_ohlcv(*args, **kwargs):  # type: ignore[override]
         raise ImportError("build_multi_timeframe_ohlcv is unavailable")
+
+    async def fetch_ohlcv(*args, **kwargs):  # type: ignore[override]
+        raise ImportError("fetch_ohlcv is unavailable")
 
     def fetch_ohlcv_sync(*args, **kwargs):  # type: ignore[override]
         raise ImportError("fetch_ohlcv_sync is unavailable")
@@ -243,13 +258,13 @@ async def build_check_all_datas_async(
     timeout: float | None = _ASYNC_BUILD_TIMEOUT_SECONDS,
     **kwargs: Any,
 ) -> Dict[str, Any] | None:
-    """Execute ``build_check_all_datas`` on a worker thread with a timeout."""
+    """Execute ``build_check_all_datas`` with a timeout that respects cancellation."""
 
     context = _prepare_snapshot_context(snapshot, kwargs.get("now_utc"))
     build_kwargs = dict(kwargs)
 
     async def _invoke() -> Dict[str, Any] | None:
-        return await asyncio.to_thread(partial(build_check_all_datas, snapshot, **build_kwargs))
+        return await build_check_all_datas(snapshot, **build_kwargs)
 
     try:
         if timeout is not None and timeout > 0:
@@ -457,14 +472,14 @@ def _resolve_window_end_ms(
     return max(candidates) if candidates else now_ms
 
 
-def _backfill_timeframe_with_rest(
+async def _backfill_timeframe_with_rest(
     frames: MutableMapping[str, List[MutableMapping[str, Any]]],
     *,
     symbol: str,
     timeframe: str,
     window_end_ms: int,
     window_hours: int,
-    fetcher: Callable[..., Mapping[str, Any]] | None = None,
+    fetcher: Callable[..., Awaitable[Mapping[str, Any]]] | Callable[..., Mapping[str, Any]] | None = None,
     minimum_required: int | None = None,
 ) -> bool:
     """Ensure the requested timeframe has at least the required candles."""
@@ -490,9 +505,16 @@ def _backfill_timeframe_with_rest(
             if available >= minimum_required:
                 return False
 
-    fetch_callable = fetcher or fetch_ohlcv_sync
+    fetch_callable = fetcher or fetch_ohlcv
     try:
-        fetched_payload = fetch_callable(symbol, timeframe, hours=max(1, window_hours))
+        if asyncio.iscoroutinefunction(fetch_callable):
+            fetched_payload = await fetch_callable(symbol, timeframe, hours=max(1, window_hours))  # type: ignore[arg-type]
+        else:
+            result = fetch_callable(symbol, timeframe, hours=max(1, window_hours))
+            if asyncio.iscoroutine(result):
+                fetched_payload = await result  # type: ignore[assignment]
+            else:
+                fetched_payload = result
     except Exception as exc:  # pragma: no cover - defensive logging
         LOGGER.warning(
             "Cold backfill request failed",
@@ -791,8 +813,8 @@ def _normalise_binance_row(row: Sequence[object]) -> Dict[str, Any] | None:
     }
 
 
-def _request_binance_minutes(
-    client: httpx.Client,
+async def _request_binance_minutes_async(
+    client: httpx.AsyncClient,
     symbol: str,
     start_ms: int,
     end_ms: int,
@@ -813,7 +835,7 @@ def _request_binance_minutes(
         if budget is not None:
             budget.raise_if_exceeded("request_binance_minutes")
         try:
-            response = client.get(BINANCE_FAPI_REST, params=params)
+            response = await client.get(BINANCE_FAPI_REST, params=params)
             response.raise_for_status()
             data = response.json()
             if isinstance(data, list):
@@ -827,9 +849,9 @@ def _request_binance_minutes(
                     remaining = budget.remaining()
                     if remaining is not None and remaining <= 0:
                         raise
-                    time.sleep(min(delay, max(0.0, remaining)))
+                    await asyncio.sleep(min(delay, max(0.0, remaining)))
                 else:
-                    time.sleep(delay)
+                    await asyncio.sleep(delay)
                 delay *= 2
                 continue
             raise
@@ -840,16 +862,16 @@ def _request_binance_minutes(
                     remaining = budget.remaining()
                     if remaining is not None and remaining <= 0:
                         raise
-                    time.sleep(min(delay, max(0.0, remaining)))
+                    await asyncio.sleep(min(delay, max(0.0, remaining)))
                 else:
-                    time.sleep(delay)
+                    await asyncio.sleep(delay)
                 delay *= 2
                 continue
             raise
     return []
 
 
-def _download_missing_minutes(
+async def _download_missing_minutes_async(
     symbol: str,
     start_ms: int,
     end_ms: int,
@@ -864,7 +886,8 @@ def _download_missing_minutes(
     downloaded = 0
 
     try:
-        with httpx.Client(timeout=httpx.Timeout(6.0, connect=3.0)) as client:
+        timeout = httpx.Timeout(6.0, connect=3.0)
+        async with httpx.AsyncClient(timeout=timeout) as client:
             for gap in gaps:
                 if budget is not None:
                     budget.raise_if_exceeded("download_missing_minutes_gap")
@@ -879,7 +902,7 @@ def _download_missing_minutes(
                         cursor + (1000 - 1) * MINUTE_INTERVAL_MS,
                     )
                     request_end = chunk_end + MINUTE_INTERVAL_MS
-                    raw_rows = _request_binance_minutes(
+                    raw_rows = await _request_binance_minutes_async(
                         client,
                         symbol,
                         cursor,
@@ -913,7 +936,7 @@ def _download_missing_minutes(
     return fetched
 
 
-def _call_download_missing_minutes(
+async def _call_download_missing_minutes_async(
     symbol: str,
     start_ms: int,
     end_ms: int,
@@ -924,10 +947,10 @@ def _call_download_missing_minutes(
     """Invoke `_download_missing_minutes` while tolerating legacy stubs without budget."""
 
     if budget is None:
-        return _download_missing_minutes(symbol, start_ms, end_ms, gaps)
+        return await _download_missing_minutes_async(symbol, start_ms, end_ms, gaps)
 
     try:
-        return _download_missing_minutes(
+        return await _download_missing_minutes_async(
             symbol,
             start_ms,
             end_ms,
@@ -938,7 +961,7 @@ def _call_download_missing_minutes(
         message = str(exc)
         if "unexpected keyword argument" not in message or "budget" not in message:
             raise
-        return _download_missing_minutes(symbol, start_ms, end_ms, gaps)
+        return await _download_missing_minutes_async(symbol, start_ms, end_ms, gaps)
 
 
 def _aggregate_from_minutes(
@@ -2465,7 +2488,7 @@ def _build_daily_vwap(
     }
 
 
-def build_check_all_datas(
+async def build_check_all_datas(
     snapshot: Mapping[str, Any],
     *,
     now_utc: datetime | None = None,
@@ -2522,7 +2545,7 @@ def build_check_all_datas(
         )
         return _insufficient_from_context(context, now_override=now_dt)
 
-    _backfill_timeframe_with_rest(
+    await _backfill_timeframe_with_rest(
         frames,
         symbol=symbol,
         timeframe="1m",
@@ -2549,7 +2572,7 @@ def build_check_all_datas(
                 extra={"stage": exc.stage, "symbol": symbol, "primary_key": primary_key},
             )
             return _insufficient_from_context(context, now_override=now_dt)
-        _backfill_timeframe_with_rest(
+        await _backfill_timeframe_with_rest(
             frames,
             symbol=symbol,
             timeframe=primary_key,
@@ -2616,7 +2639,8 @@ def build_check_all_datas(
             symbol,
             target_tf_key,
         )
-        (profile_tpo, profile_flat, profile_zones) = build_profile_package(
+        (profile_tpo, profile_flat, profile_zones) = await asyncio.to_thread(
+            build_profile_package,
             base_candles,
             sessions=sessions,
             last_n=int(profile_config.get("last_n", 3)),
@@ -2715,7 +2739,7 @@ def build_check_all_datas(
     if time_gaps:
         try:
             budget.raise_if_exceeded("download_missing_minutes_start")
-            downloaded_minutes = _call_download_missing_minutes(
+            downloaded_minutes = await _call_download_missing_minutes_async(
                 symbol,
                 window_start_ms,
                 window_end_ms,
@@ -2825,7 +2849,7 @@ def build_check_all_datas(
     if zone_history_gaps:
         try:
             budget.raise_if_exceeded("zones_history_backfill_start")
-            zone_downloaded_minutes = _call_download_missing_minutes(
+            zone_downloaded_minutes = await _call_download_missing_minutes_async(
                 symbol,
                 zones_history_start_ms,
                 window_end_ms,
@@ -3230,7 +3254,8 @@ def build_check_all_datas(
 
     if zone_frames_full:
         try:
-            detected_zones = detect_zones(
+            detected_zones = await asyncio.to_thread(
+                detect_zones,
                 frames=zone_frames_full,
                 profile_levels=profile_level_map,
                 liquidity_levels=liquidity_equal_levels,
@@ -3401,7 +3426,8 @@ def build_check_all_datas(
             if any(not zone_availability.get(tf, {}).get("ok", False) for tf in tf_candidates):
                 zones_container[zone_key] = []
 
-    liquidity_payload = build_liquidity_snapshot(
+    liquidity_payload = await asyncio.to_thread(
+        build_liquidity_snapshot,
         liquidity_frames,
         symbol=symbol,
         tick_size=tick_size_numeric,
@@ -3462,7 +3488,8 @@ def build_check_all_datas(
         liquidity_source = liquidity_payload
     elif isinstance(snapshot.get("liquidity"), Mapping):
         liquidity_source = snapshot.get("liquidity")  # type: ignore[assignment]
-    smc_blocks_list, smc_stats = detect_smc_blocks(
+    smc_blocks_list, smc_stats = await asyncio.to_thread(
+        detect_smc_blocks,
         hourly_htf,
         timeframe="1h",
         structure_flags=structure_events,

--- a/src/services/check_all_datas.py
+++ b/src/services/check_all_datas.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import Counter
 import logging
 import math
 import time
@@ -2503,6 +2504,15 @@ async def build_check_all_datas(
 
     status = "ok"
 
+    notes: List[str] = []
+    invalid_candles_count = 0
+    invalid_candle_stages: Counter[str] = Counter()
+
+    def _register_invalid_candle(_ts: int, stage: str) -> None:
+        nonlocal invalid_candles_count
+        invalid_candles_count += 1
+        invalid_candle_stages[stage] += 1
+
     budget = _TimeBudget(_BUILD_TIMEOUT_SECONDS)
 
     context = _prepare_snapshot_context(snapshot, now_utc)
@@ -2653,6 +2663,7 @@ async def build_check_all_datas(
             smooth_window=int(profile_config.get("smooth_window", 1)),
             cache_token=cache_token,
             tf_key=target_tf_key,
+            invalid_ts_handler=_register_invalid_candle,
         )
         profile_level_map = _build_profile_level_map(profile_tpo)
 
@@ -3969,12 +3980,31 @@ async def build_check_all_datas(
     if last_price_diag.get("mismatch"):
         meta_block["stream_vs_ohlcv_mismatch"] = True
 
+    meta_block["invalid_candles_count"] = invalid_candles_count
+    meta_block["invalid_candle_stages"] = dict(
+        sorted(invalid_candle_stages.items())
+    ) if invalid_candle_stages else {}
+
+    if invalid_candles_count:
+        stage_summary = ", ".join(
+            f"{stage}:{count}" for stage, count in sorted(invalid_candle_stages.items())
+        )
+        if stage_summary:
+            notes.append(
+                f"Filtered {invalid_candles_count} candles with invalid timestamps ({stage_summary})"
+            )
+        else:
+            notes.append(
+                f"Filtered {invalid_candles_count} candles with invalid timestamps"
+            )
+
     final_payload = {
         "status": status,
         "meta": meta_block,
         "data": data_payload,
         "availability": availability,
         "missing_fields": missing_fields_list,
+        "notes": notes,
     }
 
     return round_floats(final_payload)

--- a/src/services/check_all_datas.py
+++ b/src/services/check_all_datas.py
@@ -1,11 +1,13 @@
 """Snapshot builder for the inspection check-all endpoint."""
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone, time as dtime
+from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple, Set
 
 import httpx
@@ -81,6 +83,7 @@ _RETRYABLE_STATUS = {418, 429, 500, 502, 503, 504}
 _MAX_RETRIES = 5
 
 _BUILD_TIMEOUT_SECONDS = 12.0
+_ASYNC_BUILD_TIMEOUT_SECONDS = 5.0
 
 _EXPECTED_OHLCV_TFS: Tuple[str, ...] = ("1m", "3m", "5m", "15m", "1h", "4h", "1d")
 _EXPECTED_ORDERFLOW_TFS: Tuple[str, ...] = ("15m", "1h")
@@ -100,6 +103,92 @@ _EXPECTED_ZONE_KEYS: Tuple[str, ...] = (
 _COLD_BACKFILL_MIN_REQUIRED: Dict[str, int] = {
     tf: 1 for tf in _EXPECTED_OHLCV_TFS
 }
+
+
+@dataclass(slots=True)
+class _SnapshotContext:
+    """Prepared context for building inspection snapshots."""
+
+    symbol: str
+    now: datetime
+    frames: Dict[str, List[MutableMapping[str, Any]]]
+    raw_meta: Mapping[str, Any] | None
+    stream_price: float | None
+    stream_ts: int | None
+    has_now_override: bool
+
+
+def _iter_stream_candidates(
+    snapshot: Mapping[str, Any], raw_meta: Mapping[str, Any] | None
+) -> Iterable[Mapping[str, Any]]:
+    """Yield candidate live-tick payloads from a snapshot and its metadata."""
+
+    for key in ("stream", "live", "live_price", "live_tick"):
+        candidate = snapshot.get(key)
+        if isinstance(candidate, Mapping):
+            yield candidate
+
+    if isinstance(raw_meta, Mapping):
+        for key in ("stream", "live", "live_price", "ticker"):
+            candidate = raw_meta.get(key)
+            if isinstance(candidate, Mapping):
+                yield candidate
+
+
+def _resolve_stream_from_context(
+    snapshot: Mapping[str, Any], raw_meta: Mapping[str, Any] | None
+) -> Tuple[float | None, int | None]:
+    """Extract the first valid stream price/timestamp pair from the snapshot."""
+
+    for candidate in _iter_stream_candidates(snapshot, raw_meta):
+        price, ts = _normalise_stream_point(candidate)
+        if price is not None and ts is not None:
+            return price, ts
+    return None, None
+
+
+def _prepare_snapshot_context(
+    snapshot: Mapping[str, Any], now_utc: datetime | None
+) -> _SnapshotContext:
+    """Assemble the deterministic build context for an inspection snapshot."""
+
+    frames = _normalise_frames(snapshot) or {}
+    raw_meta = snapshot.get("meta") if isinstance(snapshot.get("meta"), Mapping) else None
+    symbol = str(snapshot.get("symbol") or snapshot.get("pair") or "UNKNOWN").upper()
+
+    if now_utc is None:
+        now_dt = datetime.now(UTC)
+    else:
+        if now_utc.tzinfo is None:
+            now_dt = now_utc.replace(tzinfo=UTC)
+        else:
+            now_dt = now_utc.astimezone(UTC)
+
+    stream_price, stream_ts = _resolve_stream_from_context(snapshot, raw_meta)
+
+    return _SnapshotContext(
+        symbol=symbol,
+        now=now_dt,
+        frames=frames,
+        raw_meta=raw_meta,
+        stream_price=stream_price,
+        stream_ts=stream_ts,
+        has_now_override=now_utc is not None,
+    )
+
+
+def _insufficient_from_context(
+    context: _SnapshotContext, *, now_override: datetime | None = None
+) -> Dict[str, Any]:
+    """Materialise an insufficient-data payload for the provided context."""
+
+    now_dt = now_override or context.now
+    return _build_insufficient_payload(
+        symbol=context.symbol,
+        now=now_dt,
+        stream_price=context.stream_price,
+        stream_ts=context.stream_ts,
+    )
 
 class DataQualityError(RuntimeError):
     """Raised when the inspected snapshot fails deterministic data checks."""
@@ -146,6 +235,39 @@ class _TimeBudget:
             return
         if time.monotonic() >= self.deadline:
             raise _TimeBudgetExceeded(stage)
+
+
+async def build_check_all_datas_async(
+    snapshot: Mapping[str, Any],
+    *,
+    timeout: float | None = _ASYNC_BUILD_TIMEOUT_SECONDS,
+    **kwargs: Any,
+) -> Dict[str, Any] | None:
+    """Execute ``build_check_all_datas`` on a worker thread with a timeout."""
+
+    context = _prepare_snapshot_context(snapshot, kwargs.get("now_utc"))
+    build_kwargs = dict(kwargs)
+
+    async def _invoke() -> Dict[str, Any] | None:
+        return await asyncio.to_thread(partial(build_check_all_datas, snapshot, **build_kwargs))
+
+    try:
+        if timeout is not None and timeout > 0:
+            return await asyncio.wait_for(_invoke(), timeout)
+        return await _invoke()
+    except asyncio.TimeoutError:
+        LOGGER.warning(
+            "Check-all build timed out",
+            extra={
+                "symbol": context.symbol,
+                "timeout": timeout,
+                "has_now_override": context.has_now_override,
+                "hours": build_kwargs.get("hours"),
+                "window_hours": build_kwargs.get("window_hours"),
+                "strict_window": build_kwargs.get("strict_window"),
+            },
+        )
+        return _insufficient_from_context(context)
 
 
 def _isoformat_utc(timestamp_ms: int) -> str:
@@ -2360,38 +2482,14 @@ def build_check_all_datas(
 
     budget = _TimeBudget(_BUILD_TIMEOUT_SECONDS)
 
-    frames = _normalise_frames(snapshot)
-    raw_meta = snapshot.get("meta") if isinstance(snapshot.get("meta"), Mapping) else None
-    symbol = str(snapshot.get("symbol") or snapshot.get("pair") or "UNKNOWN").upper()
-
-    if now_utc is None:
-        now_dt = datetime.now(UTC)
-    else:
-        now_dt = now_utc.astimezone(UTC)
+    context = _prepare_snapshot_context(snapshot, now_utc)
+    frames = context.frames
+    raw_meta = context.raw_meta
+    symbol = context.symbol
+    now_dt = context.now
+    stream_price = context.stream_price
+    stream_ts = context.stream_ts
     now_ms = int(now_dt.timestamp() * 1000)
-
-    stream_price: float | None = None
-    stream_ts: int | None = None
-    stream_candidates: List[Mapping[str, Any]] = []
-
-    for key in ("stream", "live", "live_price", "live_tick"):
-        candidate = snapshot.get(key)
-        if isinstance(candidate, Mapping):
-            stream_candidates.append(candidate)
-
-    if isinstance(raw_meta, Mapping):
-        for key in ("stream", "live", "live_price", "ticker"):
-            candidate = raw_meta.get(key)
-            if isinstance(candidate, Mapping):
-                stream_candidates.append(candidate)
-
-    for candidate in stream_candidates:
-        price, ts = _normalise_stream_point(candidate)
-        if price is None or ts is None:
-            continue
-        stream_price = price
-        stream_ts = ts
-        break
 
     if selection_end_ms is None:
         selection_payload = snapshot.get("selection")
@@ -2422,12 +2520,7 @@ def build_check_all_datas(
             "Time budget exceeded before seeding minute frame",
             extra={"stage": exc.stage, "symbol": symbol},
         )
-        return _build_insufficient_payload(
-            symbol=symbol,
-            now=now_dt,
-            stream_price=stream_price,
-            stream_ts=stream_ts,
-        )
+        return _insufficient_from_context(context, now_override=now_dt)
 
     _backfill_timeframe_with_rest(
         frames,
@@ -2445,12 +2538,7 @@ def build_check_all_datas(
     if not primary_key and "1m" in frames:
         primary_key = "1m"
     if not primary_key:
-        return _build_insufficient_payload(
-            symbol=symbol,
-            now=now_dt,
-            stream_price=stream_price,
-            stream_ts=stream_ts,
-        )
+        return _insufficient_from_context(context, now_override=now_dt)
 
     if not frames.get(primary_key):
         try:
@@ -2460,12 +2548,7 @@ def build_check_all_datas(
                 "Time budget exceeded before seeding primary frame",
                 extra={"stage": exc.stage, "symbol": symbol, "primary_key": primary_key},
             )
-            return _build_insufficient_payload(
-                symbol=symbol,
-                now=now_dt,
-                stream_price=stream_price,
-                stream_ts=stream_ts,
-            )
+            return _insufficient_from_context(context, now_override=now_dt)
         _backfill_timeframe_with_rest(
             frames,
             symbol=symbol,
@@ -2476,12 +2559,7 @@ def build_check_all_datas(
 
     primary_candles = frames.get(primary_key, [])
     if not primary_candles:
-        return _build_insufficient_payload(
-            symbol=symbol,
-            now=now_dt,
-            stream_price=stream_price,
-            stream_ts=stream_ts,
-        )
+        return _insufficient_from_context(context, now_override=now_dt)
 
     # Drop unused granularities to keep the payload focused on the requested set.
     frames.pop("3m", None)
@@ -2566,16 +2644,7 @@ def build_check_all_datas(
     if selection_start > selection_end:
         selection_start, selection_end = selection_end, selection_start
 
-    if now_utc is not None:
-        if now_utc.tzinfo is None:
-            now_dt = now_utc.replace(tzinfo=UTC)
-        else:
-            now_dt = now_utc.astimezone(UTC)
-    else:
-        now_dt = datetime.now(UTC)
-
-    if now_utc is not None:
-        now_ms = int(now_dt.timestamp() * 1000)
+    if context.has_now_override:
         window_end_ms = _align_to_interval(now_ms, MINUTE_INTERVAL_MS) - MINUTE_INTERVAL_MS
     else:
         window_end_ms = minute_candles[-1]["t"] if minute_candles else None
@@ -2590,12 +2659,7 @@ def build_check_all_datas(
         window_end_ms = primary_candles[-1]["t"] + max(primary_interval - MINUTE_INTERVAL_MS, 0)
 
     if window_end_ms is None:
-        return _build_insufficient_payload(
-            symbol=symbol,
-            now=now_dt,
-            stream_price=stream_price,
-            stream_ts=stream_ts,
-        )
+        return _insufficient_from_context(context, now_override=now_dt)
 
     window_end_ms = max(0, _align_to_interval(window_end_ms, MINUTE_INTERVAL_MS))
 
@@ -2682,12 +2746,7 @@ def build_check_all_datas(
                     "time_gaps": time_gaps,
                 },
             )
-            return _build_insufficient_payload(
-                symbol=symbol,
-                now=now_dt,
-                stream_price=stream_price,
-                stream_ts=stream_ts,
-            )
+            return _insufficient_from_context(context, now_override=now_dt)
         for candle in downloaded_minutes:
             ts = candle["t"]
             if ts < window_start_ms or ts > window_end_ms:
@@ -2723,12 +2782,7 @@ def build_check_all_datas(
             "Time budget exceeded before zones preparation",
             extra={"stage": exc.stage, "symbol": symbol},
         )
-        return _build_insufficient_payload(
-            symbol=symbol,
-            now=now_dt,
-            stream_price=stream_price,
-            stream_ts=stream_ts,
-        )
+        return _insufficient_from_context(context, now_override=now_dt)
 
     zones_window_hours = max(1, hours_window)
     if not strict_window:
@@ -2799,12 +2853,7 @@ def build_check_all_datas(
                     "time_gaps": zone_history_gaps,
                 },
             )
-            return _build_insufficient_payload(
-                symbol=symbol,
-                now=now_dt,
-                stream_price=stream_price,
-                stream_ts=stream_ts,
-            )
+            return _insufficient_from_context(context, now_override=now_dt)
         for candle in zone_downloaded_minutes:
             ts = candle["t"]
             if ts < zones_history_start_ms or ts > window_end_ms:

--- a/src/services/ohlc_sanitizer.py
+++ b/src/services/ohlc_sanitizer.py
@@ -1,0 +1,169 @@
+"""Helpers for sanitising OHLCV candle payloads."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import math
+from typing import Any, Iterable, Mapping, MutableMapping
+
+from .timeutils import ensure_ms_epoch
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+_TS_KEYS = ("t", "time", "openTime")
+_OPEN_KEYS = ("o", "open")
+_HIGH_KEYS = ("h", "high")
+_LOW_KEYS = ("l", "low")
+_CLOSE_KEYS = ("c", "close")
+
+
+@dataclass(slots=True)
+class SanitizedCandles:
+    """Result of sanitising a collection of OHLC candles."""
+
+    candles: list[dict[str, Any]]
+    invalid_ts: int
+    invalid_ohlc: int
+    earliest_ms: int | None
+    latest_ms: int | None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric):
+        return None
+    return float(numeric)
+
+
+def _pick_first(mapping: Mapping[str, Any], keys: Iterable[str]) -> Any:
+    for key in keys:
+        if key in mapping:
+            return mapping[key]
+    return None
+
+
+def sanitize_candles(
+    candles: Iterable[Mapping[str, Any]] | Iterable[MutableMapping[str, Any]] | None,
+    *,
+    stage: str,
+) -> SanitizedCandles:
+    """Normalise timestamps and filter invalid OHLC records."""
+
+    sanitized: list[dict[str, Any]] = []
+    invalid_ts = 0
+    invalid_ohlc = 0
+    input_count = 0
+    earliest_ms: int | None = None
+    latest_ms: int | None = None
+
+    if candles is None:
+        return SanitizedCandles([], 0, 0, None, None)
+
+    for raw in candles:
+        input_count += 1
+        if not isinstance(raw, Mapping):
+            continue
+
+        ts_value = _pick_first(raw, _TS_KEYS)
+        timestamp_ms = ensure_ms_epoch(ts_value)
+        if timestamp_ms is None:
+            invalid_ts += 1
+            LOGGER.warning(
+                "Invalid candle timestamp discarded", extra={"stage": stage, "ts": ts_value}
+            )
+            continue
+
+        open_value = _coerce_float(_pick_first(raw, _OPEN_KEYS))
+        high_value = _coerce_float(_pick_first(raw, _HIGH_KEYS))
+        low_value = _coerce_float(_pick_first(raw, _LOW_KEYS))
+        close_value = _coerce_float(_pick_first(raw, _CLOSE_KEYS))
+
+        if (
+            open_value is None
+            or high_value is None
+            or low_value is None
+            or close_value is None
+            or low_value > high_value
+            or low_value > open_value
+            or low_value > close_value
+            or high_value < open_value
+            or high_value < close_value
+        ):
+            invalid_ohlc += 1
+            LOGGER.warning(
+                "Invalid candle range discarded",
+                extra={
+                    "stage": stage,
+                    "ts": timestamp_ms,
+                    "o": open_value,
+                    "h": high_value,
+                    "l": low_value,
+                    "c": close_value,
+                },
+            )
+            continue
+
+        sanitized_candle = dict(raw)
+        sanitized_candle["t"] = timestamp_ms
+        for key in _TS_KEYS:
+            if key in sanitized_candle:
+                sanitized_candle[key] = timestamp_ms
+
+        if any(key in sanitized_candle for key in _OPEN_KEYS):
+            for key in _OPEN_KEYS:
+                if key in sanitized_candle:
+                    sanitized_candle[key] = open_value
+        else:
+            sanitized_candle["o"] = open_value
+
+        if any(key in sanitized_candle for key in _HIGH_KEYS):
+            for key in _HIGH_KEYS:
+                if key in sanitized_candle:
+                    sanitized_candle[key] = high_value
+        else:
+            sanitized_candle["h"] = high_value
+
+        if any(key in sanitized_candle for key in _LOW_KEYS):
+            for key in _LOW_KEYS:
+                if key in sanitized_candle:
+                    sanitized_candle[key] = low_value
+        else:
+            sanitized_candle["l"] = low_value
+
+        if any(key in sanitized_candle for key in _CLOSE_KEYS):
+            for key in _CLOSE_KEYS:
+                if key in sanitized_candle:
+                    sanitized_candle[key] = close_value
+        else:
+            sanitized_candle["c"] = close_value
+
+        sanitized.append(sanitized_candle)
+
+        earliest_ms = timestamp_ms if earliest_ms is None else min(earliest_ms, timestamp_ms)
+        latest_ms = timestamp_ms if latest_ms is None else max(latest_ms, timestamp_ms)
+
+    if sanitized:
+        sanitized.sort(key=lambda candle: candle.get("t", 0))
+
+    LOGGER.info(
+        "Sanitised candles",
+        extra={
+            "stage": stage,
+            "input_count": input_count,
+            "output_count": len(sanitized),
+            "invalid_ts": invalid_ts,
+            "invalid_ohlc": invalid_ohlc,
+            "earliest_ms": earliest_ms,
+            "latest_ms": latest_ms,
+        },
+    )
+
+    return SanitizedCandles(sanitized, invalid_ts, invalid_ohlc, earliest_ms, latest_ms)
+

--- a/src/services/profile.py
+++ b/src/services/profile.py
@@ -4,8 +4,78 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import date, datetime, time as dtime, timedelta, timezone
+import logging
 import math
-from typing import Any, DefaultDict, Dict, Iterable, List, Mapping, Sequence, Tuple
+from typing import (
+    Any,
+    Callable,
+    DefaultDict,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Sequence,
+    Tuple,
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+_MIN_TS_MS = 1
+_FUTURE_DRIFT = timedelta(days=1)
+
+
+InvalidTimestampHandler = Callable[[int, str], None]
+
+
+def _max_allowed_ts_ms(now: datetime | None = None) -> int:
+    """Return the inclusive upper bound for candle timestamps in milliseconds."""
+
+    base = now or datetime.now(timezone.utc)
+    return int((base + _FUTURE_DRIFT).timestamp() * 1000)
+
+
+def _report_invalid_timestamp(ts: int, *, stage: str, handler: InvalidTimestampHandler | None) -> None:
+    """Emit a warning and notify the optional handler about an invalid candle."""
+
+    LOGGER.warning("Invalid candle timestamp: %s", ts, extra={"stage": stage})
+    if handler is not None:
+        handler(ts, stage)
+
+
+def _validate_timestamp_range(
+    ts: int,
+    *,
+    max_ts: int,
+    stage: str,
+    handler: InvalidTimestampHandler | None,
+) -> int | None:
+    """Return the timestamp if it falls within the accepted range."""
+
+    if ts < _MIN_TS_MS or ts > max_ts:
+        _report_invalid_timestamp(ts, stage=stage, handler=handler)
+        return None
+    return ts
+
+
+def _safe_datetime_from_timestamp(
+    ts: int,
+    *,
+    tz: timezone,
+    max_ts: int,
+    stage: str,
+    handler: InvalidTimestampHandler | None,
+) -> datetime | None:
+    """Convert a millisecond timestamp to ``datetime`` guarding against errors."""
+
+    valid_ts = _validate_timestamp_range(ts, max_ts=max_ts, stage=stage, handler=handler)
+    if valid_ts is None:
+        return None
+    try:
+        return datetime.fromtimestamp(valid_ts / 1000.0, tz=tz)
+    except (OSError, ValueError):
+        _report_invalid_timestamp(valid_ts, stage=stage, handler=handler)
+        return None
 
 
 _PROFILE_CACHE: Dict[Tuple[Any, ...], "VolumeProfile"] = {}
@@ -69,6 +139,8 @@ def split_by_sessions(
     candles: Sequence[Mapping[str, Any]],
     sessions: Iterable[Tuple[str, dtime, dtime]],
     tz: timezone = timezone.utc,
+    *,
+    invalid_ts_handler: InvalidTimestampHandler | None = None,
 ) -> Dict[Tuple[date, str], List[Mapping[str, Any]]]:
     """Group candles by (date, session) buckets similar to VWAP sessions."""
 
@@ -77,13 +149,23 @@ def split_by_sessions(
     if not candles or not session_list:
         return buckets
 
+    max_ts = _max_allowed_ts_ms()
+
     for candle in candles:
         if not isinstance(candle, Mapping):
             continue
         ts = _extract_timestamp(candle)
         if ts is None:
             continue
-        dt = datetime.fromtimestamp(ts / 1000.0, tz=tz)
+        dt = _safe_datetime_from_timestamp(
+            ts,
+            tz=tz,
+            max_ts=max_ts,
+            stage="split_by_sessions",
+            handler=invalid_ts_handler,
+        )
+        if dt is None:
+            continue
         moment = dt.time()
         for name, start, end in session_list:
             if not _in_session(moment, start, end):
@@ -343,33 +425,42 @@ def compute_session_profiles(
     atr_multiplier: float = 0.5,
     target_bins: int = 80,
     cache_token: Any | None = None,
+    invalid_ts_handler: InvalidTimestampHandler | None = None,
 ) -> List[Dict[str, object]]:
     """Return volume profile summaries grouped by calendar day."""
 
     session_list = list(sessions)
     session_map = (
-        split_by_sessions(candles_1m, session_list) if session_list else {}
+        split_by_sessions(
+            candles_1m,
+            session_list,
+            invalid_ts_handler=invalid_ts_handler,
+        )
+        if session_list
+        else {}
     )
 
     daily_buckets: DefaultDict[date, List[Mapping[str, Any]]] = defaultdict(list)
+    if candles_1m:
+        max_ts = _max_allowed_ts_ms()
+    else:
+        max_ts = _MIN_TS_MS
+
     for candle in candles_1m:
         if not isinstance(candle, Mapping):
             continue
         ts = _extract_timestamp(candle)
         if ts is None:
             continue
-        dt = datetime.fromtimestamp(ts / 1000.0, tz=timezone.utc)
-        daily_buckets[dt.date()].append(dict(candle))
-
-
-    daily_buckets: DefaultDict[date, List[Mapping[str, Any]]] = defaultdict(list)
-    for candle in candles_1m:
-        if not isinstance(candle, Mapping):
+        dt = _safe_datetime_from_timestamp(
+            ts,
+            tz=timezone.utc,
+            max_ts=max_ts,
+            stage="compute_session_profiles",
+            handler=invalid_ts_handler,
+        )
+        if dt is None:
             continue
-        ts = _extract_timestamp(candle)
-        if ts is None:
-            continue
-        dt = datetime.fromtimestamp(ts / 1000.0, tz=timezone.utc)
         daily_buckets[dt.date()].append(dict(candle))
 
     if not daily_buckets:
@@ -556,6 +647,7 @@ def build_profile_package(
     smooth_window: int = 1,
     cache_token: Any | None = None,
     tf_key: str = "1m",
+    invalid_ts_handler: InvalidTimestampHandler | None = None,
 ) -> Tuple[List[Dict[str, object]], List[Dict[str, float]], List[Dict[str, Any]]]:
     """Compute TPO summaries, flattened profile, and derived zones."""
 
@@ -574,6 +666,7 @@ def build_profile_package(
         atr_multiplier=atr_multiplier,
         target_bins=target_bins,
         cache_token=token,
+        invalid_ts_handler=invalid_ts_handler,
     )
 
     flattened: List[Dict[str, float]] = []
@@ -582,7 +675,11 @@ def build_profile_package(
     if not tpo_entries:
         return tpo_entries, flattened, zones
 
-    session_map = split_by_sessions(candles, session_list)
+    session_map = split_by_sessions(
+        candles,
+        session_list,
+        invalid_ts_handler=invalid_ts_handler,
+    )
     latest = tpo_entries[-1] if tpo_entries else None
     latest_date = latest.get("date") if isinstance(latest, Mapping) else None
     latest_session = latest.get("session") if isinstance(latest, Mapping) else None

--- a/src/services/profile.py
+++ b/src/services/profile.py
@@ -14,68 +14,72 @@ from typing import (
     Iterable,
     List,
     Mapping,
+    MutableMapping,
     Sequence,
     Tuple,
 )
 
+from .timeutils import ensure_ms_epoch, safe_datetime_from_ms
+
 
 LOGGER = logging.getLogger(__name__)
 
-_MIN_TS_MS = 1
-_FUTURE_DRIFT = timedelta(days=1)
+
+InvalidTimestampHandler = Callable[[int | None, str], None]
 
 
-InvalidTimestampHandler = Callable[[int, str], None]
+@dataclass(slots=True)
+class SessionSplitResult:
+    """Container for session grouping results."""
+
+    buckets: Dict[Tuple[date, str], List[Mapping[str, Any]]]
+    sessions_empty: bool = False
 
 
-def _max_allowed_ts_ms(now: datetime | None = None) -> int:
-    """Return the inclusive upper bound for candle timestamps in milliseconds."""
-
-    base = now or datetime.now(timezone.utc)
-    return int((base + _FUTURE_DRIFT).timestamp() * 1000)
-
-
-def _report_invalid_timestamp(ts: int, *, stage: str, handler: InvalidTimestampHandler | None) -> None:
-    """Emit a warning and notify the optional handler about an invalid candle."""
-
-    LOGGER.warning("Invalid candle timestamp: %s", ts, extra={"stage": stage})
-    if handler is not None:
-        handler(ts, stage)
-
-
-def _validate_timestamp_range(
-    ts: int,
+def _notify_invalid_timestamp(
+    value: Any,
     *,
-    max_ts: int,
+    stage: str,
+    handler: InvalidTimestampHandler | None,
+) -> None:
+    LOGGER.warning("Invalid candle timestamp: %s", value, extra={"stage": stage})
+    if handler is not None:
+        numeric: int | None
+        try:
+            numeric = int(value) if value is not None else None
+        except (TypeError, ValueError):
+            numeric = None
+        handler(numeric, stage)
+
+
+def _extract_timestamp_ms(
+    candle: Mapping[str, Any],
+    *,
     stage: str,
     handler: InvalidTimestampHandler | None,
 ) -> int | None:
-    """Return the timestamp if it falls within the accepted range."""
+    for key in ("t", "time", "openTime"):
+        if key not in candle:
+            continue
+        ms = ensure_ms_epoch(candle.get(key))
+        if ms is None:
+            _notify_invalid_timestamp(candle.get(key), stage=stage, handler=handler)
+            return None
+        return ms
+    return None
 
-    if ts < _MIN_TS_MS or ts > max_ts:
-        _report_invalid_timestamp(ts, stage=stage, handler=handler)
-        return None
-    return ts
 
-
-def _safe_datetime_from_timestamp(
-    ts: int,
+def _datetime_from_ms(
+    ms: int,
     *,
     tz: timezone,
-    max_ts: int,
     stage: str,
     handler: InvalidTimestampHandler | None,
 ) -> datetime | None:
-    """Convert a millisecond timestamp to ``datetime`` guarding against errors."""
-
-    valid_ts = _validate_timestamp_range(ts, max_ts=max_ts, stage=stage, handler=handler)
-    if valid_ts is None:
-        return None
-    try:
-        return datetime.fromtimestamp(valid_ts / 1000.0, tz=tz)
-    except (OSError, ValueError):
-        _report_invalid_timestamp(valid_ts, stage=stage, handler=handler)
-        return None
+    dt = safe_datetime_from_ms(ms, tz)
+    if dt is None:
+        _notify_invalid_timestamp(ms, stage=stage, handler=handler)
+    return dt
 
 
 _PROFILE_CACHE: Dict[Tuple[Any, ...], "VolumeProfile"] = {}
@@ -107,15 +111,7 @@ def _in_session(moment: dtime, start: dtime, end: dtime) -> bool:
 
 
 def _extract_timestamp(candle: Mapping[str, Any]) -> int | None:
-    for key in ("t", "time", "openTime"):
-        raw = candle.get(key)
-        if raw is None:
-            continue
-        try:
-            return int(raw)
-        except (TypeError, ValueError):
-            continue
-    return None
+    return _extract_timestamp_ms(candle, stage="profile_legacy", handler=None)
 
 
 def _session_extrema(
@@ -141,26 +137,31 @@ def split_by_sessions(
     tz: timezone = timezone.utc,
     *,
     invalid_ts_handler: InvalidTimestampHandler | None = None,
-) -> Dict[Tuple[date, str], List[Mapping[str, Any]]]:
+) -> SessionSplitResult:
     """Group candles by (date, session) buckets similar to VWAP sessions."""
 
     buckets: Dict[Tuple[date, str], List[Mapping[str, Any]]] = {}
     session_list = list(sessions)
-    if not candles or not session_list:
-        return buckets
+    if not session_list:
+        return SessionSplitResult(buckets, sessions_empty=bool(candles))
 
-    max_ts = _max_allowed_ts_ms()
+    input_count = 0
+    accepted = 0
 
     for candle in candles:
         if not isinstance(candle, Mapping):
             continue
-        ts = _extract_timestamp(candle)
+        input_count += 1
+        ts = _extract_timestamp_ms(
+            candle,
+            stage="split_by_sessions",
+            handler=invalid_ts_handler,
+        )
         if ts is None:
             continue
-        dt = _safe_datetime_from_timestamp(
+        dt = _datetime_from_ms(
             ts,
             tz=tz,
-            max_ts=max_ts,
             stage="split_by_sessions",
             handler=invalid_ts_handler,
         )
@@ -176,7 +177,10 @@ def split_by_sessions(
             bucket_key = (session_date, name)
             bucket = buckets.setdefault(bucket_key, [])
             bucket.append(dict(candle))
-    return buckets
+            accepted += 1
+
+    sessions_empty = input_count > 0 and accepted == 0
+    return SessionSplitResult(buckets, sessions_empty=sessions_empty)
 
 
 def _compute_true_ranges(candles: Sequence[Mapping[str, Any]]) -> List[float]:
@@ -430,32 +434,32 @@ def compute_session_profiles(
     """Return volume profile summaries grouped by calendar day."""
 
     session_list = list(sessions)
-    session_map = (
-        split_by_sessions(
+    if session_list:
+        split_result = split_by_sessions(
             candles_1m,
             session_list,
             invalid_ts_handler=invalid_ts_handler,
         )
-        if session_list
-        else {}
-    )
+        session_map: Dict[Tuple[date, str], List[Mapping[str, Any]]] = split_result.buckets
+    else:
+        split_result = SessionSplitResult({}, sessions_empty=bool(candles_1m))
+        session_map = {}
 
     daily_buckets: DefaultDict[date, List[Mapping[str, Any]]] = defaultdict(list)
-    if candles_1m:
-        max_ts = _max_allowed_ts_ms()
-    else:
-        max_ts = _MIN_TS_MS
 
     for candle in candles_1m:
         if not isinstance(candle, Mapping):
             continue
-        ts = _extract_timestamp(candle)
+        ts = _extract_timestamp_ms(
+            candle,
+            stage="compute_session_profiles",
+            handler=invalid_ts_handler,
+        )
         if ts is None:
             continue
-        dt = _safe_datetime_from_timestamp(
+        dt = _datetime_from_ms(
             ts,
             tz=timezone.utc,
-            max_ts=max_ts,
             stage="compute_session_profiles",
             handler=invalid_ts_handler,
         )
@@ -648,11 +652,17 @@ def build_profile_package(
     cache_token: Any | None = None,
     tf_key: str = "1m",
     invalid_ts_handler: InvalidTimestampHandler | None = None,
+    meta_out: MutableMapping[str, Any] | None = None,
 ) -> Tuple[List[Dict[str, object]], List[Dict[str, float]], List[Dict[str, Any]]]:
     """Compute TPO summaries, flattened profile, and derived zones."""
 
+    if meta_out is not None and "sessions_empty" not in meta_out:
+        meta_out["sessions_empty"] = False
+
     session_list = list(sessions)
     if not candles or not session_list:
+        if meta_out is not None and candles:
+            meta_out["sessions_empty"] = True
         return [], [], []
 
     token = cache_token
@@ -675,11 +685,14 @@ def build_profile_package(
     if not tpo_entries:
         return tpo_entries, flattened, zones
 
-    session_map = split_by_sessions(
+    split_session_result = split_by_sessions(
         candles,
         session_list,
         invalid_ts_handler=invalid_ts_handler,
     )
+    if meta_out is not None and split_session_result.sessions_empty:
+        meta_out["sessions_empty"] = True
+    session_map = split_session_result.buckets
     latest = tpo_entries[-1] if tpo_entries else None
     latest_date = latest.get("date") if isinstance(latest, Mapping) else None
     latest_session = latest.get("session") if isinstance(latest, Mapping) else None

--- a/src/services/timeutils.py
+++ b/src/services/timeutils.py
@@ -1,0 +1,85 @@
+"""Utilities for working with market-data timestamps."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import logging
+import math
+from typing import Any
+
+
+LOGGER = logging.getLogger(__name__)
+
+_FUTURE_DRIFT = timedelta(days=1)
+_UTC = timezone.utc
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Best-effort conversion of ``value`` to an integer."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, bool):  # bool is an ``int`` subclass, skip explicitly
+        return None
+
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        return int(value)
+
+    try:
+        text = str(value).strip()
+    except Exception:  # pragma: no cover - defensive guard
+        return None
+
+    if not text:
+        return None
+
+    try:
+        return int(text)
+    except ValueError:
+        try:
+            numeric = float(text)
+        except ValueError:
+            return None
+        if not math.isfinite(numeric):
+            return None
+        return int(numeric)
+
+
+def ensure_ms_epoch(value: Any) -> int | None:
+    """Normalise timestamps to milliseconds since the Unix epoch."""
+
+    numeric = _coerce_int(value)
+    if numeric is None:
+        return None
+
+    abs_value = abs(numeric)
+    if abs_value >= 10**14:
+        numeric //= 1000
+    elif abs_value < 10**10:
+        numeric *= 1000
+
+    if numeric <= 0:
+        return None
+
+    now = datetime.now(_UTC)
+    max_allowed = int((now + _FUTURE_DRIFT).timestamp() * 1000)
+    if numeric > max_allowed:
+        return None
+
+    return numeric
+
+
+def safe_datetime_from_ms(ms: int, tz: timezone) -> datetime | None:
+    """Convert milliseconds to ``datetime`` guarding against runtime errors."""
+
+    try:
+        return datetime.fromtimestamp(ms / 1000.0, tz=tz)
+    except (OverflowError, OSError, ValueError):
+        LOGGER.warning("Failed to convert timestamp to datetime", extra={"ms": ms})
+        return None
+

--- a/tests/test_api_payload_schema.py
+++ b/tests/test_api_payload_schema.py
@@ -47,7 +47,7 @@ def snapshot_storage(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def stub_missing_minutes(monkeypatch):
-    def filler(symbol: str, start_ms: int, end_ms: int, gaps):
+    async def filler(symbol: str, start_ms: int, end_ms: int, gaps):
         candles = []
         for gap in gaps:
             cursor = int(gap["from"])
@@ -66,7 +66,7 @@ def stub_missing_minutes(monkeypatch):
                 cursor += 60_000
         return candles
 
-    monkeypatch.setattr(check_all_datas, "_download_missing_minutes", filler)
+    monkeypatch.setattr(check_all_datas, "_download_missing_minutes_async", filler)
 
     def filler_htf(symbol: str, gaps, *, fetcher, target):
         inserted = 0

--- a/tests/test_check_all_datas.py
+++ b/tests/test_check_all_datas.py
@@ -184,7 +184,14 @@ def test_check_all_returns_structured_payload(client: TestClient) -> None:
     assert meta["last_price_source"] in {"stream", "ohlcv"}
     assert "stale" in meta
     assert meta["invalid_candles_count"] >= 0
+    assert meta["invalid_ts_count"] >= 0
+    assert meta["invalid_ohlc_count"] >= 0
+    assert meta["invalid_candles_count"] == meta["invalid_ts_count"] + meta["invalid_ohlc_count"]
     assert isinstance(meta["invalid_candle_stages"], dict)
+    assert meta.get("sanitized") is True
+    assert isinstance(meta.get("sessions_empty"), bool)
+    for stage_counts in meta["invalid_candle_stages"].values():
+        assert isinstance(stage_counts, dict)
 
     data_block = body["data"]
 
@@ -283,7 +290,8 @@ async def test_check_all_reports_invalid_timestamps() -> None:
     assert result is not None
     assert result["status"] == "ok"
     meta = result["meta"]
-    assert meta["invalid_candles_count"] >= 1
+    assert meta["invalid_ts_count"] >= 1
+    assert meta["invalid_candles_count"] >= meta["invalid_ts_count"]
     assert meta["invalid_candle_stages"]
     assert result["notes"], "expected notes for invalid timestamps"
     assert any("invalid timestamps" in note for note in result["notes"])
@@ -467,3 +475,41 @@ async def test_async_builder_timeout_returns_insufficient(monkeypatch):
     assert result is not None
     assert result["status"] == "insufficient_data"
     assert result["meta"]["insufficient_reason"] == "stale_or_unseeded_buffers"
+
+def test_build_inspection_error_payload_sets_reason() -> None:
+    now = datetime(2024, 1, 1, tzinfo=UTC)
+    snapshot = {
+        "symbol": "BTCUSDT",
+        "tf": "1m",
+        "frames": {"1m": {"tf": "1m", "candles": []}},
+    }
+    payload = check_all_datas.build_inspection_error_payload(
+        snapshot,
+        now_utc=now,
+        missing_fields=["ohlcv.1m"],
+        reason="invalid_timestamps",
+    )
+    assert payload["status"] == "insufficient_data"
+    assert "ohlcv.1m" in payload["missing_fields"]
+    meta = payload["meta"]
+    assert meta["insufficient_reason"] == "invalid_timestamps"
+    assert meta.get("sanitized") is True
+
+def test_check_all_returns_insufficient_on_internal_error(client: TestClient, monkeypatch) -> None:
+    base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+    payload = _build_snapshot_payload(base, count=60)
+
+    create_response = client.post("/inspection/snapshot", json=payload)
+    assert create_response.status_code == 200
+    snapshot_id = create_response.json()["snapshot_id"]
+
+    async def boom(*args, **kwargs):  # pragma: no cover - monkeypatch helper
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("src.api.app.build_check_all_datas_async", boom)
+
+    response = client.get("/inspection/check-all", params={"snapshot": snapshot_id})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "insufficient_data"
+    assert body["meta"].get("insufficient_reason") == "invalid_timestamps"

--- a/tests/test_check_all_datas.py
+++ b/tests/test_check_all_datas.py
@@ -158,7 +158,8 @@ def test_check_all_returns_structured_payload(client: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
 
-    assert set(body.keys()) == {"meta", "data", "availability", "missing_fields"}
+    assert set(body.keys()) == {"status", "meta", "data", "availability", "missing_fields"}
+    assert body["status"] == "ok"
 
     meta = body["meta"]
     assert meta["symbol"] == payload["symbol"]

--- a/tests/test_check_all_datas.py
+++ b/tests/test_check_all_datas.py
@@ -165,7 +165,14 @@ def test_check_all_returns_structured_payload(client: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
 
-    assert set(body.keys()) == {"status", "meta", "data", "availability", "missing_fields"}
+    assert set(body.keys()) == {
+        "status",
+        "meta",
+        "data",
+        "availability",
+        "missing_fields",
+        "notes",
+    }
     assert body["status"] == "ok"
 
     meta = body["meta"]
@@ -176,6 +183,8 @@ def test_check_all_returns_structured_payload(client: TestClient) -> None:
     assert "last_tf" in meta
     assert meta["last_price_source"] in {"stream", "ohlcv"}
     assert "stale" in meta
+    assert meta["invalid_candles_count"] >= 0
+    assert isinstance(meta["invalid_candle_stages"], dict)
 
     data_block = body["data"]
 
@@ -188,6 +197,9 @@ def test_check_all_returns_structured_payload(client: TestClient) -> None:
     assert set(orderflow.keys()) == {"15m", "1h"}
     for block in orderflow.values():
         assert isinstance(block["per_bar"], list)
+
+    assert isinstance(body["notes"], list)
+    assert not body["notes"]
 
     vwap_tpo = data_block["vwap_tpo"]
     assert vwap_tpo["daily"]["open_utc"].startswith("2024-01-02T00:00:00")
@@ -244,6 +256,37 @@ def test_check_all_returns_structured_payload(client: TestClient) -> None:
     availability = body["availability"]
     assert set(availability.keys()) == {"ohlcv", "vwap_sessions", "zones", "orderflow"}
     assert isinstance(body["missing_fields"], list)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_check_all_reports_invalid_timestamps() -> None:
+    base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+    payload = _build_snapshot_payload(base, count=120)
+    candles = payload["candles"]
+    bad_index = len(candles) // 2
+    candles[bad_index]["t"] = -1
+
+    snapshot = {
+        "id": "invalid-ts",  # stable identifier for caching paths
+        "symbol": payload["symbol"],
+        "tf": "1m",
+        "frames": {"1m": {"tf": "1m", "candles": candles}},
+        "selection": {"start": candles[0]["t"], "end": candles[-1]["t"]},
+    }
+
+    result = await check_all_datas.build_check_all_datas(
+        snapshot,
+        now_utc=base + timedelta(hours=4),
+        hours=4,
+    )
+
+    assert result is not None
+    assert result["status"] == "ok"
+    meta = result["meta"]
+    assert meta["invalid_candles_count"] >= 1
+    assert meta["invalid_candle_stages"]
+    assert result["notes"], "expected notes for invalid timestamps"
+    assert any("invalid timestamps" in note for note in result["notes"])
 
 
 def test_topup_limits_window_to_last_collection(client: TestClient) -> None:

--- a/tests/test_check_all_datas.py
+++ b/tests/test_check_all_datas.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import asyncio
+import time
 
 import pytest
 from fastapi.testclient import TestClient
@@ -393,3 +395,28 @@ def test_vwap_tpo_sessions_include_aliases(client: TestClient) -> None:
     assert composite_day["poc"] is not None
     assert composite_day["vah"] is not None
     assert composite_day["val"] is not None
+
+
+def test_async_builder_timeout_returns_insufficient(monkeypatch):
+    base = datetime(2024, 5, 1, 0, 0, tzinfo=UTC)
+    snapshot = _build_snapshot_payload(base, count=5)
+
+    def slow_builder(snapshot, **kwargs):
+        time.sleep(0.2)
+        return {
+            "status": "ok",
+            "meta": {"symbol": snapshot.get("symbol", "UNKNOWN")},
+            "data": {},
+            "availability": {},
+            "missing_fields": [],
+        }
+
+    monkeypatch.setattr(check_all_datas, "build_check_all_datas", slow_builder)
+
+    result = asyncio.run(
+        check_all_datas.build_check_all_datas_async(snapshot, timeout=0.05)
+    )
+
+    assert result is not None
+    assert result["status"] == "insufficient_data"
+    assert result["meta"]["insufficient_reason"] == "stale_or_unseeded_buffers"

--- a/tests/test_check_all_datas.py
+++ b/tests/test_check_all_datas.py
@@ -32,6 +32,11 @@ def preset_storage(tmp_path, monkeypatch):
     presets._STORAGE_LOADED = False
 
 
+@pytest.fixture
+def anyio_backend():
+    yield "asyncio"
+
+
 @pytest.fixture(autouse=True)
 def snapshot_storage(tmp_path, monkeypatch):
     storage_dir = tmp_path / "snapshots"
@@ -45,7 +50,7 @@ def snapshot_storage(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def stub_binance_minutes(monkeypatch):
-    def filler(symbol: str, start_ms: int, end_ms: int, gaps):
+    async def filler(symbol: str, start_ms: int, end_ms: int, gaps):
         candles = []
         for gap in gaps:
             cursor = int(gap["from"])
@@ -64,7 +69,7 @@ def stub_binance_minutes(monkeypatch):
                 cursor += 60_000
         return candles
 
-    monkeypatch.setattr(check_all_datas, "_download_missing_minutes", filler)
+    monkeypatch.setattr(check_all_datas, "_download_missing_minutes_async", filler)
 
     def filler_htf(symbol: str, gaps, *, fetcher, target):
         inserted = 0
@@ -397,12 +402,13 @@ def test_vwap_tpo_sessions_include_aliases(client: TestClient) -> None:
     assert composite_day["val"] is not None
 
 
-def test_async_builder_timeout_returns_insufficient(monkeypatch):
+@pytest.mark.anyio("asyncio")
+async def test_async_builder_timeout_returns_insufficient(monkeypatch):
     base = datetime(2024, 5, 1, 0, 0, tzinfo=UTC)
     snapshot = _build_snapshot_payload(base, count=5)
 
-    def slow_builder(snapshot, **kwargs):
-        time.sleep(0.2)
+    async def slow_builder(snapshot, **kwargs):
+        await asyncio.sleep(0.2)
         return {
             "status": "ok",
             "meta": {"symbol": snapshot.get("symbol", "UNKNOWN")},
@@ -413,9 +419,7 @@ def test_async_builder_timeout_returns_insufficient(monkeypatch):
 
     monkeypatch.setattr(check_all_datas, "build_check_all_datas", slow_builder)
 
-    result = asyncio.run(
-        check_all_datas.build_check_all_datas_async(snapshot, timeout=0.05)
-    )
+    result = await check_all_datas.build_check_all_datas_async(snapshot, timeout=0.05)
 
     assert result is not None
     assert result["status"] == "insufficient_data"

--- a/tests/test_last_price_meta.py
+++ b/tests/test_last_price_meta.py
@@ -66,6 +66,11 @@ def stub_check_all_dependencies(monkeypatch):
     yield
 
 
+@pytest.fixture
+def anyio_backend():
+    yield "asyncio"
+
+
 def _snapshot_with_candles(candles: Sequence[Dict[str, Any]], entry_price: float) -> Dict[str, Any]:
     return {
         "symbol": "BTCUSDT",
@@ -76,7 +81,10 @@ def _snapshot_with_candles(candles: Sequence[Dict[str, Any]], entry_price: float
     }
 
 
-def test_last_price_prefers_minute_candle_over_analysis(stub_check_all_dependencies) -> None:
+@pytest.mark.anyio("asyncio")
+async def test_last_price_prefers_minute_candle_over_analysis(
+    stub_check_all_dependencies,
+) -> None:
     base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
     candles = []
     for offset, close in enumerate((110.0, 116.0)):
@@ -95,7 +103,7 @@ def test_last_price_prefers_minute_candle_over_analysis(stub_check_all_dependenc
     snapshot = _snapshot_with_candles(candles, entry_price=101.0)
     now_dt = base + timedelta(minutes=2)
 
-    result = check_all_datas.build_check_all_datas(snapshot, now_utc=now_dt)
+    result = await check_all_datas.build_check_all_datas(snapshot, now_utc=now_dt)
 
     assert result is not None
     meta = result["meta"]
@@ -106,7 +114,8 @@ def test_last_price_prefers_minute_candle_over_analysis(stub_check_all_dependenc
     assert meta["stale"] is False
 
 
-def test_snapshot_staleness_marks_meta(stub_check_all_dependencies) -> None:
+@pytest.mark.anyio("asyncio")
+async def test_snapshot_staleness_marks_meta(stub_check_all_dependencies) -> None:
     base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
     stale_time = base
     candles = [
@@ -122,7 +131,7 @@ def test_snapshot_staleness_marks_meta(stub_check_all_dependencies) -> None:
     snapshot = _snapshot_with_candles(candles, entry_price=99.0)
     now_dt = stale_time + timedelta(minutes=10)
 
-    result = check_all_datas.build_check_all_datas(snapshot, now_utc=now_dt)
+    result = await check_all_datas.build_check_all_datas(snapshot, now_utc=now_dt)
 
     assert result is not None
     meta = result["meta"]
@@ -133,7 +142,10 @@ def test_snapshot_staleness_marks_meta(stub_check_all_dependencies) -> None:
     assert meta["stale"] is True
 
 
-def test_last_price_updates_when_minute_candles_change(stub_check_all_dependencies) -> None:
+@pytest.mark.anyio("asyncio")
+async def test_last_price_updates_when_minute_candles_change(
+    stub_check_all_dependencies,
+) -> None:
     base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
     first_candles = [
         {
@@ -156,7 +168,7 @@ def test_last_price_updates_when_minute_candles_change(stub_check_all_dependenci
     snapshot = _snapshot_with_candles(first_candles, entry_price=100.0)
     now_dt = base + timedelta(minutes=2)
 
-    initial = check_all_datas.build_check_all_datas(snapshot, now_utc=now_dt)
+    initial = await check_all_datas.build_check_all_datas(snapshot, now_utc=now_dt)
     assert initial["meta"]["last_price"] == pytest.approx(108.0)
 
     updated_candles = first_candles[:-1] + [
@@ -172,13 +184,16 @@ def test_last_price_updates_when_minute_candles_change(stub_check_all_dependenci
     snapshot["frames"]["1m"]["candles"] = updated_candles
     snapshot["selection"]["end"] = updated_candles[-1]["t"]
 
-    refreshed = check_all_datas.build_check_all_datas(snapshot, now_utc=base + timedelta(minutes=3))
+    refreshed = await check_all_datas.build_check_all_datas(
+        snapshot, now_utc=base + timedelta(minutes=3)
+    )
     assert refreshed["meta"]["last_price"] == pytest.approx(123.0)
     assert refreshed["meta"]["last_tf"] == "1m"
     assert refreshed["meta"]["last_price_source"] == "ohlcv"
 
 
-def test_stream_price_overrides_candle(stub_check_all_dependencies) -> None:
+@pytest.mark.anyio("asyncio")
+async def test_stream_price_overrides_candle(stub_check_all_dependencies) -> None:
     base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
     candles = [
         {
@@ -194,7 +209,9 @@ def test_stream_price_overrides_candle(stub_check_all_dependencies) -> None:
     stream_ts = int((base + timedelta(minutes=1, seconds=2)).timestamp() * 1000)
     snapshot["stream"] = {"price": 107.5, "ts": stream_ts}
 
-    result = check_all_datas.build_check_all_datas(snapshot, now_utc=base + timedelta(minutes=1, seconds=3))
+    result = await check_all_datas.build_check_all_datas(
+        snapshot, now_utc=base + timedelta(minutes=1, seconds=3)
+    )
 
     meta = result["meta"]
     assert meta["last_price"] == pytest.approx(107.5)
@@ -204,7 +221,8 @@ def test_stream_price_overrides_candle(stub_check_all_dependencies) -> None:
     assert meta.get("insufficient_reason") is None
 
 
-def test_stream_vs_ohlcv_mismatch_flag(stub_check_all_dependencies) -> None:
+@pytest.mark.anyio("asyncio")
+async def test_stream_vs_ohlcv_mismatch_flag(stub_check_all_dependencies) -> None:
     base = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
     candle_ts = int(base.timestamp() * 1000)
     candles = [
@@ -221,7 +239,7 @@ def test_stream_vs_ohlcv_mismatch_flag(stub_check_all_dependencies) -> None:
     stream_ts = candle_ts + 60_000 + 4_000
     snapshot["stream"] = {"price": 101.5, "ts": stream_ts}
 
-    result = check_all_datas.build_check_all_datas(
+    result = await check_all_datas.build_check_all_datas(
         snapshot,
         now_utc=base + timedelta(minutes=1, seconds=10),
     )

--- a/tests/test_last_price_meta.py
+++ b/tests/test_last_price_meta.py
@@ -175,7 +175,7 @@ async def test_last_price_updates_when_minute_candles_change(
         {
             "t": int((base + timedelta(minutes=2)).timestamp() * 1000),
             "o": 108.0,
-            "h": 118.0,
+            "h": 123.0,
             "l": 105.0,
             "c": 123.0,
             "v": 4.0,

--- a/tests/test_ohlc_sanitizer.py
+++ b/tests/test_ohlc_sanitizer.py
@@ -1,0 +1,28 @@
+from src.services.ohlc_sanitizer import sanitize_candles
+
+
+def test_sanitize_candles_normalises_timestamps() -> None:
+    candles = [
+        {"t": 1_690_000_000, "o": "1", "h": "2", "l": "0.5", "c": "1.5"},
+        {"time": 1_690_000_060_000, "open": 1.6, "high": 1.8, "low": 1.5, "close": 1.7},
+    ]
+    result = sanitize_candles(candles, stage="test")
+    assert result.invalid_ts == 0
+    assert result.invalid_ohlc == 0
+    assert result.candles[0]["t"] == 1_690_000_000_000
+    assert result.candles[1]["t"] == 1_690_000_060_000
+    assert result.candles[0]["o"] == 1.0
+    assert result.candles[0]["c"] == 1.5
+
+
+def test_sanitize_candles_counts_invalid_entries() -> None:
+    candles = [
+        {"t": 0, "o": 1, "h": 2, "l": 0.5, "c": 1.5},
+        {"t": 1_690_000_000_000, "o": 1, "h": 0.8, "l": 1.2, "c": 0.9},
+        {"t": 1_690_000_060_000, "o": 1.0, "h": 1.5, "l": 0.9, "c": 1.2},
+    ]
+    result = sanitize_candles(candles, stage="test_invalid")
+    assert result.invalid_ts == 1
+    assert result.invalid_ohlc == 1
+    assert len(result.candles) == 1
+    assert result.candles[0]["t"] == 1_690_000_060_000

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -161,8 +161,10 @@ def test_split_by_sessions_groups_candles() -> None:
     base = datetime(2024, 5, 1, tzinfo=timezone.utc)
     candles = make_unimodal(n=600, base=base)
     sessions = list(Meta.iter_vwap_sessions())
-    buckets = split_by_sessions(candles, sessions)
+    result = split_by_sessions(candles, sessions)
+    buckets = result.buckets
     assert buckets, "Expected session buckets"
+    assert result.sessions_empty is False
     asia_key = (base.date(), sessions[0][0])
     london_key = (base.date(), sessions[1][0])
     assert asia_key in buckets

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timezone, timedelta
+
+from src.services.timeutils import ensure_ms_epoch, safe_datetime_from_ms
+
+
+def test_ensure_ms_epoch_normalises_seconds() -> None:
+    seconds_value = 1_690_000_000
+    ms_value = ensure_ms_epoch(seconds_value)
+    assert ms_value == seconds_value * 1000
+
+
+def test_ensure_ms_epoch_handles_microseconds() -> None:
+    micro_value = 1_690_000_000_000_000
+    ms_value = ensure_ms_epoch(micro_value)
+    assert ms_value == micro_value // 1000
+
+
+def test_ensure_ms_epoch_rejects_out_of_range() -> None:
+    assert ensure_ms_epoch(0) is None
+    assert ensure_ms_epoch(-1) is None
+    future = datetime.now(timezone.utc) + timedelta(days=2)
+    assert ensure_ms_epoch(int(future.timestamp() * 1000)) is None
+
+
+def test_safe_datetime_from_ms_returns_datetime() -> None:
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    ms_value = int(now.timestamp() * 1000)
+    dt = safe_datetime_from_ms(ms_value, timezone.utc)
+    assert dt == now
+
+
+def test_safe_datetime_from_ms_handles_overflow() -> None:
+    assert safe_datetime_from_ms(10 ** 20, timezone.utc) is None


### PR DESCRIPTION
## Summary
- add reusable helpers to seed OHLCV frames from REST data and build an insufficient-data payload
- backfill minute/primary frames before processing live buffers and surface an insufficient status instead of returning null
- expose a status field in the check-all response and update tests for the richer contract

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68debddfca0883249f17d7e764c48fa9