### PR TITLE
Ensure summary builds expose aggregated timeframes

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -42,6 +42,8 @@ from ..services import (
     build_check_all_datas_async,
     build_inspection_error_payload,
     collect_recent_summary,
+    collect_last_session_detailed,
+    SessionCollectionResult,
 )
 from ..services.zones import Config as ZonesConfig, detect_zones
 
@@ -894,7 +896,7 @@ async def inspection_check_all(
         now_override = parsed
 
     mode_value = (mode or "selection").strip().lower()
-    if mode_value not in {"selection", "summary", "topup"}:
+    if mode_value not in {"selection", "summary", "topup", "session_detailed"}:
         mode_value = "selection"
 
     collection_reference = now_override or datetime.now(timezone.utc)
@@ -976,6 +978,29 @@ async def inspection_check_all(
             extra={**branch_log, "status": status_value},
         )
         set_last_collection_time(collection_reference)
+        return JSONResponse(payload)
+
+    if mode_value == "session_detailed":
+        symbol = target_snapshot.get("symbol") if isinstance(target_snapshot, Mapping) else None
+        if not symbol:
+            meta_block = target_snapshot.get("meta") if isinstance(target_snapshot, Mapping) else None
+            if isinstance(meta_block, Mapping):
+                symbol = meta_block.get("symbol")
+        if not symbol:
+            raise HTTPException(status_code=400, detail="Snapshot symbol missing")
+        try:
+            session_result: SessionCollectionResult = await collect_last_session_detailed(symbol, now_override)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.exception(
+                "inspection_check_all:session_detailed_failed",
+                extra={**log_extra, "error": str(exc)},
+            )
+            raise HTTPException(status_code=500, detail="Session collection failed") from exc
+        payload = session_result.as_dict()
+        LOGGER.info(
+            "inspection_check_all:finished",
+            extra={**log_extra, "mode": mode_value, "status": payload.get("status")},
+        )
         return JSONResponse(payload)
 
     if mode_value == "topup":

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -44,6 +44,7 @@ from .shared_candles_store import (
     merge_shared_candles,
 )
 from .summary_collector import collect_recent_summary, CollectionSummary
+from .session_collector import collect_last_session_detailed, SessionCollectionResult
 from .ohlc import (
     TIMEFRAME_WINDOWS,
     fetch_ohlcv,
@@ -105,4 +106,6 @@ __all__ = [
     "apply_enrichment_to_payload",
     "collect_recent_summary",
     "CollectionSummary",
+    "collect_last_session_detailed",
+    "SessionCollectionResult",
 ]

--- a/src/services/check_all_datas.py
+++ b/src/services/check_all_datas.py
@@ -2661,6 +2661,30 @@ async def build_check_all_datas(
     minute_candles = _deduplicate_sorted(frames.get("1m", []))
     frames["1m"] = minute_candles
 
+    if minute_candles:
+        try:
+            aggregated_block = build_multi_timeframe_ohlcv(minute_candles)
+        except Exception:  # pragma: no cover - defensive guard
+            aggregated_block = {}
+        else:
+            for tf_key in ("3m", "5m", "15m", "1h", "4h", "1d"):
+                existing_series = frames.get(tf_key)
+                if existing_series:
+                    continue
+                tf_payload = aggregated_block.get(tf_key)
+                if not isinstance(tf_payload, Mapping):
+                    continue
+                raw_series = tf_payload.get("candles")
+                if not isinstance(raw_series, Sequence):
+                    continue
+                coerced_series = [
+                    dict(entry)
+                    for entry in raw_series
+                    if isinstance(entry, Mapping)
+                ]
+                if coerced_series:
+                    frames[tf_key] = coerced_series
+
     profile_config = resolve_profile_config(symbol, raw_meta)
     profile_meta: Dict[str, Any] = {}
     sessions = list(VWAP_TPO_SESSIONS)

--- a/src/services/inspection.py
+++ b/src/services/inspection.py
@@ -2512,6 +2512,7 @@ def render_inspection_page(
     const diagnosticsPre = document.getElementById("diagnostics-json");
     const checkAllPre = document.getElementById("checkall-json");
     const summaryButton = document.getElementById("collect-summary");
+    const sessionDetailedButton = document.getElementById("btn_collect_last_session_detailed");
     const topupButton = document.getElementById("collect-topup");
     const collectSelectionButton = document.getElementById("collect-selection");
     const checkAllHours = document.getElementById("checkall-hours");
@@ -3117,6 +3118,9 @@ def render_inspection_page(
       if (summaryButton) {
         summaryButton.disabled = !liveCapable || !presetReady;
       }
+      if (sessionDetailedButton) {
+        sessionDetailedButton.disabled = !liveCapable || !presetReady;
+      }
       if (topupButton) {
         topupButton.disabled = !liveCapable || !presetReady;
       }
@@ -3451,6 +3455,63 @@ def render_inspection_page(
       } finally {
         if (summaryButton) {
           summaryButton.disabled = false;
+        }
+        if (createdSnapshotId) {
+          refreshSnapshots({ quiet: true }).catch((err) => {
+            console.warn("Не удалось обновить список снэпшотов", err);
+          });
+        }
+        updateCheckAllState();
+      }
+    }
+
+    async function requestSessionDetailedData() {
+      if (sessionDetailedButton) {
+        sessionDetailedButton.disabled = true;
+      }
+
+      let createdSnapshotId = null;
+
+      try {
+        updateStatus("Собираем подробные данные по последней сессии...", "info");
+        const { snapshotId } = await captureLiveSnapshot({ lookbackDays: 1, mode: "session_detailed" });
+        createdSnapshotId = snapshotId;
+        state.snapshotId = snapshotId;
+        updateCheckAllState();
+        if (sessionDetailedButton) {
+          sessionDetailedButton.disabled = true;
+        }
+        if (snapshotSelect) {
+          snapshotSelect.value = snapshotId;
+        }
+        const url = new URL("/inspection/check-all", window.location.origin);
+        url.searchParams.set("snapshot", snapshotId);
+        url.searchParams.set("mode", "session_detailed");
+        const response = await fetch(url.toString(), {
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+        });
+        if (response.status === 204) {
+          state.checkAll = null;
+          setJson(checkAllPre, null);
+          updateStatus("Не удалось собрать данные по последней сессии", "warning");
+          return;
+        }
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = await response.json();
+        state.checkAll = payload;
+        setJson(checkAllPre, payload);
+        updateStatus("Сессионный отчёт готов", "success");
+      } catch (error) {
+        console.error(error);
+        state.checkAll = null;
+        setJson(checkAllPre, null);
+        updateStatus("Ошибка при сборе данных по последней сессии", "error");
+      } finally {
+        if (sessionDetailedButton) {
+          sessionDetailedButton.disabled = false;
         }
         if (createdSnapshotId) {
           refreshSnapshots({ quiet: true }).catch((err) => {
@@ -4131,6 +4192,14 @@ def render_inspection_page(
       });
     }
 
+    if (sessionDetailedButton) {
+      sessionDetailedButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        requestSessionDetailedData();
+      });
+    }
+
     if (topupButton) {
       topupButton.addEventListener("click", (event) => {
         event.preventDefault();
@@ -4288,6 +4357,7 @@ def render_inspection_page(
             <p class=\"panel-lead\">Собирайте актуальную информацию без сохранения снэпшотов на сервере.</p>
             <div class=\"collection-actions\">
               <button id=\"collect-summary\" class=\"primary\" type=\"button\">Собрать информацию за последние 3 дня</button>
+              <button id=\"btn_collect_last_session_detailed\" class=\"secondary\" type=\"button\" title=\"Последняя завершённая или текущая активная сессия с полнотой ≥90%\">Собрать информацию за последнюю сессию подробно</button>
               <button id=\"collect-topup\" class=\"secondary\" type=\"button\">Дособрать данные</button>
               <button id=\"collect-selection\" class=\"secondary\" type=\"button\" disabled>Собрать информацию за выбранный период</button>
             </div>

--- a/src/services/session_collector.py
+++ b/src/services/session_collector.py
@@ -1,0 +1,178 @@
+"""Placeholder session-detailed collector for the inspection panel."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, time as dtime, timedelta, timezone
+from typing import Any, Dict, Mapping, MutableMapping
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - Python <3.9 fallback
+    ZoneInfo = None  # type: ignore[assignment]
+
+
+BERLIN_TZ = ZoneInfo("Europe/Berlin") if ZoneInfo else timezone.utc
+
+_SESSION_WINDOWS = (
+    ("asia", dtime(hour=0, minute=0), dtime(hour=8, minute=0)),
+    ("london", dtime(hour=8, minute=0), dtime(hour=16, minute=0)),
+    ("ny", dtime(hour=14, minute=30), dtime(hour=22, minute=30)),
+)
+
+
+@dataclass(slots=True)
+class SessionWindow:
+    """Resolved trading session window in UTC."""
+
+    name: str
+    open_utc: datetime
+    close_utc: datetime
+    is_active: bool
+
+
+@dataclass(slots=True)
+class SessionCollectionResult:
+    """Structured response for session-detailed collection."""
+
+    symbol: str
+    status: str
+    session: SessionWindow
+    coverage_pct: float
+    missing_fields: tuple[str, ...]
+
+    def as_dict(self) -> Dict[str, Any]:
+        open_iso = _to_iso(self.session.open_utc)
+        close_iso = _to_iso(self.session.close_utc)
+        meta_block: Dict[str, Any] = {
+            "symbol": self.symbol,
+            "tz": "Europe/Berlin",
+            "last_price": None,
+            "last_ts_utc": close_iso,
+            "data_freshness_sec": None,
+            "stale": True,
+        }
+
+        session_block: Dict[str, Any] = {
+            "name": self.session.name,
+            "open_utc": open_iso,
+            "close_utc": close_iso,
+            "coverage_pct": round(self.coverage_pct, 5),
+            "active": self.session.is_active,
+        }
+
+        availability: Dict[str, Any] = {
+            "ohlcv": {tf: False for tf in ("1m", "3m", "5m", "15m", "1h")},
+            "orderflow": {"delta": False, "cvd": False, "footprint": False},
+            "vwap_sessions": {self.session.name: False},
+        }
+
+        data_block: Dict[str, Any] = {
+            "ohlcv": {
+                "1m": {"bars": []},
+                "3m": {"bars": []},
+                "5m": {"bars": []},
+                "1m_rollups": [],
+                "15m_compact": [],
+                "1h_compact": [],
+            },
+            "orderflow": {
+                "per_bar": [],
+                "delta_cvd_compact": [],
+                "metrics": {"delta": False, "cvd": False, "footprint": False},
+            },
+            "vwap_tpo": {
+                "daily": {},
+                "sessions": {
+                    self.session.name: {
+                        "vwap": None,
+                        "sd1": None,
+                        "sd2": None,
+                        "poc": None,
+                        "vah": None,
+                        "val": None,
+                        "ib_high": None,
+                        "ib_low": None,
+                        "high": None,
+                        "low": None,
+                    }
+                },
+            },
+            "zones": {"top": [], "counts": {}},
+            "liquidity_targets": [],
+        }
+
+        payload: Dict[str, Any] = {
+            "schema": "session_detailed.v1",
+            "status": self.status,
+            "meta": meta_block,
+            "session": session_block,
+            "data": data_block,
+            "availability": availability,
+            "missing_fields": list(self.missing_fields),
+            "notes": [],
+        }
+
+        if self.coverage_pct < 0.9 and "ohlcv.coverage" not in payload["missing_fields"]:
+            payload["missing_fields"].append("ohlcv.coverage")
+        return payload
+
+
+def _to_iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _resolve_session_window(now_utc: datetime) -> SessionWindow:
+    tz = BERLIN_TZ or timezone.utc
+    local_now = now_utc.astimezone(tz)
+    candidates: list[SessionWindow] = []
+
+    for name, start_time, end_time in _SESSION_WINDOWS:
+        start_local = datetime.combine(local_now.date(), start_time, tz)
+        end_local = datetime.combine(local_now.date(), end_time, tz)
+        if end_local <= start_local:
+            end_local += timedelta(days=1)
+        open_utc = start_local.astimezone(timezone.utc)
+        close_utc = end_local.astimezone(timezone.utc)
+        is_active = start_local <= local_now <= end_local
+        window = SessionWindow(name=name, open_utc=open_utc, close_utc=close_utc, is_active=is_active)
+        candidates.append(window)
+        if is_active:
+            return window
+
+    # pick the closest past window
+    past_windows = [window for window in candidates if window.close_utc <= now_utc]
+    if past_windows:
+        past_windows.sort(key=lambda window: window.close_utc, reverse=True)
+        return past_windows[0]
+
+    # fallback to previous day's last window
+    yesterday = now_utc - timedelta(days=1)
+    return _resolve_session_window(
+        datetime.combine(yesterday.date(), dtime.min, tzinfo=timezone.utc) + timedelta(hours=12)
+    )
+
+
+async def collect_last_session_detailed(symbol: str, now: datetime | None = None) -> SessionCollectionResult:
+    """Collect detailed data for the latest trading session.
+
+    Current implementation returns a placeholder payload marking the session as insufficient
+    until dedicated data aggregation is implemented.
+    """
+
+    now_dt = now.astimezone(timezone.utc) if isinstance(now, datetime) else datetime.now(timezone.utc)
+    session_window = _resolve_session_window(now_dt)
+    missing_fields = (
+        "ohlcv.coverage",
+        "orderflow.coverage",
+        "orderflow.delta",
+        "orderflow.cvd",
+        "orderflow.footprint",
+    )
+    return SessionCollectionResult(
+        symbol=symbol,
+        status="insufficient_data",
+        session=session_window,
+        coverage_pct=0.0,
+        missing_fields=missing_fields,
+    )
+

--- a/src/services/summary_collector.py
+++ b/src/services/summary_collector.py
@@ -256,13 +256,18 @@ async def _fill_gap(
 
     while cursor <= gap_end:
         page_end = min(gap_end, cursor + page_span - interval_ms)
+        # Match the ChartGapViewer strategy by sizing the Binance page limit to the
+        # actual gap width.  This keeps requests tight to the missing window while
+        # still respecting the hard 1000 candle ceiling enforced by the REST API.
+        approx_bars = max(1, ((page_end - cursor) // interval_ms) + 1)
+        page_limit = min(MAX_PAGE_LIMIT, max(approx_bars, 50))
         raw_rows = await _request_klines(
             client,
             symbol=symbol,
             interval=interval,
             start_ms=cursor,
             end_ms=page_end + interval_ms,
-            limit=MAX_PAGE_LIMIT,
+            limit=page_limit,
             bucket=bucket,
         )
         requests += 1

--- a/src/services/summary_collector.py
+++ b/src/services/summary_collector.py
@@ -373,14 +373,33 @@ async def collect_recent_summary(
                 continue
             first_expected = _align_to_interval(start_ms, interval_ms)
             last_expected = _align_to_interval(now_ms, interval_ms)
+            if end_ms is None:
+                # Live invocations should not expect the still-forming candle at the
+                # window tail.  Skipping that bar prevents an endless loop where
+                # the collector keeps re-requesting the most recent minute even
+                # though the exchange has not closed it yet.
+                tail_open = now_ms - last_expected < interval_ms
+                last_closed = last_expected - interval_ms if tail_open else last_expected
+            else:
+                last_closed = last_expected
+            if last_closed < first_expected:
+                summaries[interval] = IntervalSummary(
+                    gaps_total=0,
+                    gaps_filled=0,
+                    candles_written=0,
+                    dropped_candles=0,
+                    requests=0,
+                    remaining_gaps=[],
+                )
+                continue
             existing = await _fetch_existing(
                 repo,
                 symbol=symbol,
                 interval=interval,
                 start_ms=first_expected,
-                end_ms=last_expected,
+                end_ms=last_closed,
             )
-            gaps = _compute_gaps(first_expected, last_expected, interval_ms, existing)
+            gaps = _compute_gaps(first_expected, last_closed, interval_ms, existing)
             if not gaps:
                 summaries[interval] = IntervalSummary(
                     gaps_total=0,
@@ -413,9 +432,9 @@ async def collect_recent_summary(
                 symbol=symbol,
                 interval=interval,
                 start_ms=first_expected,
-                end_ms=last_expected,
+                end_ms=last_closed,
             )
-            remaining = _compute_gaps(first_expected, last_expected, interval_ms, refreshed)
+            remaining = _compute_gaps(first_expected, last_closed, interval_ms, refreshed)
             summaries[interval] = IntervalSummary(
                 gaps_total=len(gaps),
                 gaps_filled=sum(1 for item in gap_summaries if item.candles_written > 0),

--- a/tests/test_check_all_datas.py
+++ b/tests/test_check_all_datas.py
@@ -453,6 +453,30 @@ def test_vwap_tpo_sessions_include_aliases(client: TestClient) -> None:
     assert composite_day["val"] is not None
 
 
+def test_session_detailed_mode_returns_placeholder(client: TestClient) -> None:
+    base = datetime(2024, 5, 1, 7, 0, tzinfo=UTC)
+    payload = _build_snapshot_payload(base, count=120)
+
+    create_response = client.post("/inspection/snapshot", json=payload)
+    assert create_response.status_code == 200
+    snapshot_id = create_response.json()["snapshot_id"]
+
+    response = client.get(
+        "/inspection/check-all",
+        params={"snapshot": snapshot_id, "mode": "session_detailed"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["schema"] == "session_detailed.v1"
+    assert body["status"] == "insufficient_data"
+    assert body["meta"]["symbol"] == payload["symbol"]
+    assert body["meta"]["tz"] == "Europe/Berlin"
+    assert "session" in body
+    assert body["session"]["coverage_pct"] == 0.0
+    assert "ohlcv.coverage" in body["missing_fields"]
+
+
 @pytest.mark.anyio("asyncio")
 async def test_async_builder_timeout_returns_insufficient(monkeypatch):
     base = datetime(2024, 5, 1, 0, 0, tzinfo=UTC)

--- a/tests/test_summary_collector.py
+++ b/tests/test_summary_collector.py
@@ -57,6 +57,9 @@ async def test_collect_recent_summary_fills_only_missing(monkeypatch):
     )
 
     assert calls, "Expected at least one REST call for missing gaps"
+    # ChartGapViewer mirrors Binance page sizing with a minimum of 50 candles,
+    # verify the collector does the same when only a handful of bars are missing.
+    assert calls[0][2] == 50
     fetched_opens = repo.fetch_open_times(symbol, interval, start_ms, end_ms)
     expected = [start_ms + i * interval_ms for i in range(5)]
     for ts in expected:

--- a/tests/test_summary_collector.py
+++ b/tests/test_summary_collector.py
@@ -1,8 +1,10 @@
 import pytest
+from datetime import datetime, timezone
 
 from src.services.ohlc import TIMEFRAME_TO_MS
 from src.services.summary_collector import collect_recent_summary
 import src.services.summary_collector as summary_collector
+
 import src.services.candles_repository as candles_repository
 
 
@@ -96,6 +98,49 @@ async def test_collect_recent_summary_skips_when_complete(monkeypatch):
         symbol,
         days=1,
         end_ms=end_ms,
+        intervals=[interval],
+        start_ms=start_ms,
+    )
+
+    interval_summary = result.intervals[interval]
+    assert interval_summary.gaps_total == 0
+    assert interval_summary.requests == 0
+    assert interval_summary.remaining_gaps == []
+
+
+async def test_collect_recent_summary_ignores_open_tail(monkeypatch):
+    symbol = "XRPUSDT"
+    interval = "1m"
+    repo = candles_repository.get_repository()
+    interval_ms = TIMEFRAME_TO_MS[interval]
+    start_ms = 1_701_000_000_000
+    start_ms = (start_ms // interval_ms) * interval_ms
+
+    seed = [
+        {"t": start_ms + i * interval_ms, "o": 50.0, "h": 51.0, "l": 49.5, "c": 50.5, "v": 0.5}
+        for i in range(5)
+    ]
+    repo.upsert_candles(symbol, interval, seed, stage="test.seed")
+
+    now_ms = start_ms + interval_ms * 5 + interval_ms // 2
+
+    class FrozenDateTime:
+        @staticmethod
+        def now(tz=None):
+            base = datetime.fromtimestamp(now_ms / 1000, tz=timezone.utc)
+            if tz is None:
+                return base.replace(tzinfo=None)
+            return base.astimezone(tz)
+
+    async def fail_request(*args, **kwargs):
+        raise AssertionError("_request_klines should not be invoked for an open tail")
+
+    monkeypatch.setattr(summary_collector, "datetime", FrozenDateTime)
+    monkeypatch.setattr(summary_collector, "_request_klines", fail_request)
+
+    result = await collect_recent_summary(
+        symbol,
+        days=1,
         intervals=[interval],
         start_ms=start_ms,
     )


### PR DESCRIPTION
## Summary
- backfill higher timeframe candle frames from the 1m seed when they are missing
- guard against aggregation failures while keeping existing snapshot data intact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfccc597d48324802b79d5b1a5fb00