### PR TITLE
Configure tracing logger level via APP_TRACE flag

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -45,6 +45,7 @@ from ..services import (
     collect_last_session_detailed,
     SessionCollectionResult,
 )
+from ..services import tracing as tracing_utils
 from ..services.zones import Config as ZonesConfig, detect_zones
 
 from ..services.book import fetch_orderbook
@@ -61,6 +62,7 @@ from ..version import APP_VERSION
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 LOGGER = logging.getLogger(__name__)
+TRACE_LOGGER = tracing_utils.LOGGER.getChild("api.inspection")
 CHECK_ALL_BUILD_TIMEOUT = 5.0
 
 
@@ -923,6 +925,10 @@ async def inspection_check_all(
                 symbol = meta_block.get("symbol")
         collection_summary_payload: Dict[str, Any] | None = None
         if isinstance(symbol, str) and symbol:
+            TRACE_LOGGER.debug(
+                "inspection.summary_collection:starting",
+                extra={**branch_log, "symbol": symbol, "days": days},
+            )
             try:
                 summary_result = await collect_recent_summary(symbol, days=days)
                 collection_summary_payload = summary_result.as_dict()
@@ -931,12 +937,30 @@ async def inspection_check_all(
                     "candles_written": summary_result.candles_written,
                     "dropped_candles": summary_result.dropped_candles,
                 }
+                TRACE_LOGGER.debug(
+                    "inspection.summary_collection:completed",
+                    extra={
+                        **branch_log,
+                        "symbol": symbol,
+                        "requests": summary_result.requests,
+                        "candles_written": summary_result.candles_written,
+                        "dropped_candles": summary_result.dropped_candles,
+                    },
+                )
             except Exception as exc:  # pragma: no cover - defensive logging
                 LOGGER.warning(
                     "inspection_check_all:summary_collection_failed",
                     extra={**branch_log, "error": str(exc)},
                 )
+                TRACE_LOGGER.debug(
+                    "inspection.summary_collection:failed",
+                    extra={**branch_log, "symbol": symbol, "error": str(exc)},
+                )
         try:
+            TRACE_LOGGER.debug(
+                "inspection.summary_collection:building_payload",
+                extra={**branch_log, "has_summary": collection_summary_payload is not None},
+            )
             payload = await build_check_all_datas_async(
                 target_snapshot,
                 now_utc=now_override,
@@ -968,6 +992,10 @@ async def inspection_check_all(
             LOGGER.info("inspection_check_all:finished", extra={**branch_log, "status": None})
             return Response(status_code=204)
         payload = _prepare_summary_payload(dict(payload))
+        TRACE_LOGGER.debug(
+            "inspection.summary_collection:payload_ready",
+            extra={**branch_log, "status": payload.get("status")},
+        )
         if collection_summary_payload:
             meta_block = payload.get("meta")
             if isinstance(meta_block, MutableMapping):
@@ -988,6 +1016,10 @@ async def inspection_check_all(
                 symbol = meta_block.get("symbol")
         if not symbol:
             raise HTTPException(status_code=400, detail="Snapshot symbol missing")
+        TRACE_LOGGER.debug(
+            "inspection.session_collection:starting",
+            extra={**log_extra, "symbol": symbol},
+        )
         try:
             session_result: SessionCollectionResult = await collect_last_session_detailed(symbol, now_override)
         except Exception as exc:  # pragma: no cover - defensive logging
@@ -995,8 +1027,21 @@ async def inspection_check_all(
                 "inspection_check_all:session_detailed_failed",
                 extra={**log_extra, "error": str(exc)},
             )
+            TRACE_LOGGER.debug(
+                "inspection.session_collection:failed",
+                extra={**log_extra, "symbol": symbol, "error": str(exc)},
+            )
             raise HTTPException(status_code=500, detail="Session collection failed") from exc
         payload = session_result.as_dict()
+        TRACE_LOGGER.debug(
+            "inspection.session_collection:completed",
+            extra={
+                **log_extra,
+                "symbol": symbol,
+                "status": payload.get("status"),
+                "coverage_pct": payload.get("session", {}).get("coverage_pct"),
+            },
+        )
         LOGGER.info(
             "inspection_check_all:finished",
             extra={**log_extra, "mode": mode_value, "status": payload.get("status")},

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence,
 from datetime import datetime, timedelta, timezone
 from math import ceil
 
-from fastapi import Body, FastAPI, HTTPException, Query, Request, Response
+from fastapi import Body, FastAPI, HTTPException, Query, Request, Response, WebSocket, WebSocketDisconnect
+from starlette.websockets import WebSocketState
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -47,6 +48,7 @@ from ..services import (
 )
 from ..services import tracing as tracing_utils
 from ..services.zones import Config as ZonesConfig, detect_zones
+from ..services.progress import ProgressReporter, emit_progress
 
 from ..services.book import fetch_orderbook
 from ..services.derivatives import fetch_derivatives
@@ -211,6 +213,156 @@ def _fallback_footprint(candles: Sequence[CandleIn]) -> List[Dict[str, object]]:
             "absorption": abs(delta) > 100,
         })
     return footprint
+
+
+async def _run_summary_workflow(
+    target_snapshot: Mapping[str, Any],
+    *,
+    days: int,
+    window_hours: int,
+    now_override: datetime | None,
+    branch_log: Dict[str, Any],
+    progress: ProgressReporter | None = None,
+) -> Tuple[Dict[str, Any] | None, Dict[str, Any] | None]:
+    symbol = target_snapshot.get("symbol") if isinstance(target_snapshot, Mapping) else None
+    if not symbol:
+        meta_block = target_snapshot.get("meta") if isinstance(target_snapshot, Mapping) else None
+        if isinstance(meta_block, Mapping):
+            symbol = meta_block.get("symbol")
+
+    collection_summary_payload: Dict[str, Any] | None = None
+    if isinstance(symbol, str) and symbol:
+        TRACE_LOGGER.debug(
+            "inspection.summary_collection:starting",
+            extra={**branch_log, "symbol": symbol, "days": days},
+        )
+        await emit_progress(
+            progress,
+            "inspection.summary_collection:starting",
+            symbol=symbol,
+            days=days,
+            window_hours=window_hours,
+        )
+        try:
+            summary_result = await collect_recent_summary(symbol, days=days, progress=progress)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.warning(
+                "inspection_check_all:summary_collection_failed",
+                extra={**branch_log, "symbol": symbol, "error": str(exc)},
+            )
+            TRACE_LOGGER.debug(
+                "inspection.summary_collection:failed",
+                extra={**branch_log, "symbol": symbol, "error": str(exc)},
+            )
+            await emit_progress(
+                progress,
+                "inspection.summary_collection:failed",
+                symbol=symbol,
+                error=str(exc),
+            )
+        else:
+            collection_summary_payload = summary_result.as_dict()
+            branch_log["summary_collection"] = {
+                "requests": summary_result.requests,
+                "candles_written": summary_result.candles_written,
+                "dropped_candles": summary_result.dropped_candles,
+            }
+            TRACE_LOGGER.debug(
+                "inspection.summary_collection:completed",
+                extra={
+                    **branch_log,
+                    "symbol": symbol,
+                    "requests": summary_result.requests,
+                    "candles_written": summary_result.candles_written,
+                    "dropped_candles": summary_result.dropped_candles,
+                },
+            )
+            await emit_progress(
+                progress,
+                "inspection.summary_collection:completed",
+                symbol=symbol,
+                requests=summary_result.requests,
+                candles_written=summary_result.candles_written,
+                dropped_candles=summary_result.dropped_candles,
+            )
+
+    TRACE_LOGGER.debug(
+        "inspection.summary_collection:building_payload",
+        extra={**branch_log, "has_summary": collection_summary_payload is not None},
+    )
+    await emit_progress(
+        progress,
+        "inspection.summary_collection:building_payload",
+        has_summary=collection_summary_payload is not None,
+        window_hours=window_hours,
+    )
+    payload = await build_check_all_datas_async(
+        target_snapshot,
+        now_utc=now_override,
+        window_hours=window_hours,
+        timeout=CHECK_ALL_BUILD_TIMEOUT,
+    )
+    TRACE_LOGGER.debug(
+        "inspection.summary_collection:payload_ready",
+        extra={
+            **branch_log,
+            "status": payload.get("status") if isinstance(payload, Mapping) else None,
+        },
+    )
+    await emit_progress(
+        progress,
+        "inspection.summary_collection:payload_ready",
+        status=payload.get("status") if isinstance(payload, Mapping) else None,
+    )
+    return payload, collection_summary_payload
+
+
+async def _run_session_workflow(
+    symbol: str,
+    *,
+    now_override: datetime | None,
+    progress: ProgressReporter | None = None,
+) -> SessionCollectionResult:
+    TRACE_LOGGER.debug(
+        "inspection.session_collection:starting",
+        extra={"symbol": symbol},
+    )
+    await emit_progress(
+        progress,
+        "inspection.session_collection:starting",
+        symbol=symbol,
+    )
+    try:
+        result = await collect_last_session_detailed(symbol, now_override, progress=progress)
+    except Exception as exc:
+        TRACE_LOGGER.debug(
+            "inspection.session_collection:failed",
+            extra={"symbol": symbol, "error": str(exc)},
+        )
+        await emit_progress(
+            progress,
+            "inspection.session_collection:failed",
+            symbol=symbol,
+            error=str(exc),
+        )
+        raise
+    result_payload = result.as_dict()
+    TRACE_LOGGER.debug(
+        "inspection.session_collection:completed",
+        extra={
+            "symbol": symbol,
+            "status": result_payload.get("status"),
+            "coverage_pct": result_payload.get("session", {}).get("coverage_pct"),
+        },
+    )
+    await emit_progress(
+        progress,
+        "inspection.session_collection:completed",
+        symbol=symbol,
+        status=result.status,
+        coverage_pct=result.coverage_pct,
+    )
+    return result
 
 
 def _fallback_cvd(footprint: Sequence[Mapping[str, object]]) -> List[Dict[str, object]]:
@@ -918,54 +1070,14 @@ async def inspection_check_all(
         window_hours = max(1, days * 24)
         branch_log = dict(log_extra)
         branch_log["window_hours"] = window_hours
-        symbol = target_snapshot.get("symbol") if isinstance(target_snapshot, Mapping) else None
-        if not symbol:
-            meta_block = target_snapshot.get("meta") if isinstance(target_snapshot, Mapping) else None
-            if isinstance(meta_block, Mapping):
-                symbol = meta_block.get("symbol")
         collection_summary_payload: Dict[str, Any] | None = None
-        if isinstance(symbol, str) and symbol:
-            TRACE_LOGGER.debug(
-                "inspection.summary_collection:starting",
-                extra={**branch_log, "symbol": symbol, "days": days},
-            )
-            try:
-                summary_result = await collect_recent_summary(symbol, days=days)
-                collection_summary_payload = summary_result.as_dict()
-                branch_log["summary_collection"] = {
-                    "requests": summary_result.requests,
-                    "candles_written": summary_result.candles_written,
-                    "dropped_candles": summary_result.dropped_candles,
-                }
-                TRACE_LOGGER.debug(
-                    "inspection.summary_collection:completed",
-                    extra={
-                        **branch_log,
-                        "symbol": symbol,
-                        "requests": summary_result.requests,
-                        "candles_written": summary_result.candles_written,
-                        "dropped_candles": summary_result.dropped_candles,
-                    },
-                )
-            except Exception as exc:  # pragma: no cover - defensive logging
-                LOGGER.warning(
-                    "inspection_check_all:summary_collection_failed",
-                    extra={**branch_log, "error": str(exc)},
-                )
-                TRACE_LOGGER.debug(
-                    "inspection.summary_collection:failed",
-                    extra={**branch_log, "symbol": symbol, "error": str(exc)},
-                )
         try:
-            TRACE_LOGGER.debug(
-                "inspection.summary_collection:building_payload",
-                extra={**branch_log, "has_summary": collection_summary_payload is not None},
-            )
-            payload = await build_check_all_datas_async(
+            payload, collection_summary_payload = await _run_summary_workflow(
                 target_snapshot,
-                now_utc=now_override,
+                days=days,
                 window_hours=window_hours,
-                timeout=CHECK_ALL_BUILD_TIMEOUT,
+                now_override=now_override,
+                branch_log=branch_log,
             )
         except DataQualityError as exc:
             LOGGER.warning(
@@ -992,10 +1104,6 @@ async def inspection_check_all(
             LOGGER.info("inspection_check_all:finished", extra={**branch_log, "status": None})
             return Response(status_code=204)
         payload = _prepare_summary_payload(dict(payload))
-        TRACE_LOGGER.debug(
-            "inspection.summary_collection:payload_ready",
-            extra={**branch_log, "status": payload.get("status")},
-        )
         if collection_summary_payload:
             meta_block = payload.get("meta")
             if isinstance(meta_block, MutableMapping):
@@ -1016,32 +1124,18 @@ async def inspection_check_all(
                 symbol = meta_block.get("symbol")
         if not symbol:
             raise HTTPException(status_code=400, detail="Snapshot symbol missing")
-        TRACE_LOGGER.debug(
-            "inspection.session_collection:starting",
-            extra={**log_extra, "symbol": symbol},
-        )
         try:
-            session_result: SessionCollectionResult = await collect_last_session_detailed(symbol, now_override)
+            session_result: SessionCollectionResult = await _run_session_workflow(
+                symbol,
+                now_override=now_override,
+            )
         except Exception as exc:  # pragma: no cover - defensive logging
             LOGGER.exception(
                 "inspection_check_all:session_detailed_failed",
                 extra={**log_extra, "error": str(exc)},
             )
-            TRACE_LOGGER.debug(
-                "inspection.session_collection:failed",
-                extra={**log_extra, "symbol": symbol, "error": str(exc)},
-            )
             raise HTTPException(status_code=500, detail="Session collection failed") from exc
         payload = session_result.as_dict()
-        TRACE_LOGGER.debug(
-            "inspection.session_collection:completed",
-            extra={
-                **log_extra,
-                "symbol": symbol,
-                "status": payload.get("status"),
-                "coverage_pct": payload.get("session", {}).get("coverage_pct"),
-            },
-        )
         LOGGER.info(
             "inspection_check_all:finished",
             extra={**log_extra, "mode": mode_value, "status": payload.get("status")},
@@ -1153,6 +1247,284 @@ async def inspection_check_all(
     )
 
     return JSONResponse(payload)
+
+
+@app.websocket("/inspection/ws/progress")
+async def inspection_progress_ws(websocket: WebSocket) -> None:
+    await websocket.accept()
+
+    async def reporter(event: str, payload: Dict[str, Any]) -> None:
+        if websocket.client_state is not WebSocketState.CONNECTED:
+            return
+        message = {"type": "progress", "event": event, "data": payload}
+        try:
+            await websocket.send_json(message)
+        except (RuntimeError, WebSocketDisconnect):
+            pass
+
+    def _normalise_payload(value: Any) -> Dict[str, Any]:
+        if isinstance(value, Mapping):
+            return dict(value)
+        return {}
+
+    def _parse_mode(value: Any) -> str | None:
+        if isinstance(value, str):
+            candidate = value.strip().lower()
+            if candidate in {"summary", "session_detailed"}:
+                return candidate
+        return None
+
+    def _parse_summary_days(value: Any) -> int | None:
+        try:
+            candidate = int(value)
+        except (TypeError, ValueError):
+            return None
+        return candidate if candidate > 0 else None
+
+    def _parse_now(value: Any) -> datetime | None:
+        if isinstance(value, str) and value:
+            try:
+                parsed = datetime.fromisoformat(value)
+            except ValueError:
+                return None
+            if parsed.tzinfo is None:
+                return parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc)
+        return None
+
+    def _effective_summary_days(mode: str, override: int | None) -> int | None:
+        if mode != "summary":
+            return None
+        return override if override is not None else 3
+
+    mode_value = "summary"
+    summary_days_override: int | None = None
+    now_override: datetime | None = None
+
+    while True:
+        try:
+            incoming = await websocket.receive_json()
+        except WebSocketDisconnect:
+            return
+        except Exception:
+            await websocket.send_json({"type": "error", "message": "invalid_initial_payload"})
+            await websocket.close(code=1003)
+            return
+
+        message_type = incoming.get("type")
+        if message_type == "client_progress":
+            event_name = str(incoming.get("event") or "client.progress").strip() or "client.progress"
+            payload_dict = _normalise_payload(incoming.get("data"))
+            TRACE_LOGGER.debug(
+                "inspection.ws_client_progress",
+                extra={"event": event_name, "payload": payload_dict},
+            )
+            await reporter(
+                "inspection.ws:client_progress",
+                {"event": event_name, "payload": payload_dict},
+            )
+            continue
+        if message_type == "prepare":
+            mode_candidate = _parse_mode(incoming.get("mode"))
+            if mode_candidate is not None:
+                mode_value = mode_candidate
+            summary_candidate = _parse_summary_days(incoming.get("summary_days"))
+            if summary_candidate is not None:
+                summary_days_override = summary_candidate
+            now_candidate = _parse_now(incoming.get("now"))
+            if now_candidate is not None:
+                now_override = now_candidate
+            TRACE_LOGGER.debug(
+                "inspection.ws_prepare",
+                extra={
+                    "mode": mode_value,
+                    "summary_days": _effective_summary_days(mode_value, summary_days_override),
+                    "has_now_override": now_override is not None,
+                },
+            )
+            await reporter(
+                "inspection.ws:prepared",
+                {
+                    "mode": mode_value,
+                    "summary_days": _effective_summary_days(mode_value, summary_days_override),
+                    "has_now_override": now_override is not None,
+                },
+            )
+            continue
+        if message_type in {None, "start"}:
+            initial = incoming
+            break
+        await websocket.send_json({"type": "error", "message": "unsupported_message"})
+        await websocket.close(code=1003)
+        return
+
+    mode_candidate = _parse_mode(initial.get("mode"))
+    if mode_candidate is not None:
+        mode_value = mode_candidate
+    if mode_value not in {"summary", "session_detailed"}:
+        mode_value = "summary"
+
+    summary_candidate = _parse_summary_days(initial.get("summary_days"))
+    if summary_candidate is not None:
+        summary_days_override = summary_candidate
+
+    now_candidate = _parse_now(initial.get("now"))
+    if now_candidate is not None:
+        now_override = now_candidate
+
+    snapshot_id = initial.get("snapshot")
+    if not snapshot_id or not isinstance(snapshot_id, str):
+        await websocket.send_json({"type": "error", "message": "snapshot_id required"})
+        await websocket.close(code=1003)
+        return
+
+    target_snapshot = get_snapshot(snapshot_id)
+    if target_snapshot is None:
+        await websocket.send_json({"type": "error", "message": "snapshot not found"})
+        await websocket.close(code=1003)
+        return
+
+    await reporter(
+        "inspection.ws:start",
+        {
+            "mode": mode_value,
+            "snapshot": snapshot_id,
+            "summary_days": _effective_summary_days(mode_value, summary_days_override),
+            "has_now_override": now_override is not None,
+        },
+    )
+
+    collection_reference = now_override or datetime.now(timezone.utc)
+    log_extra: Dict[str, Any] = {
+        "snapshot_id": target_snapshot.get("id"),
+        "mode": mode_value,
+        "selection_start": None,
+        "selection_end": None,
+        "hours": None,
+        "has_now_override": now_override is not None,
+    }
+    LOGGER.info("inspection_check_all:start", extra=log_extra)
+
+    if mode_value == "summary":
+        days = summary_days_override if summary_days_override is not None else 3
+        window_hours = max(1, days * 24)
+        branch_log = dict(log_extra)
+        branch_log["window_hours"] = window_hours
+        branch_log["summary_days"] = days
+        collection_summary_payload: Dict[str, Any] | None = None
+        try:
+            payload, collection_summary_payload = await _run_summary_workflow(
+                target_snapshot,
+                days=days,
+                window_hours=window_hours,
+                now_override=now_override,
+                branch_log=branch_log,
+                progress=reporter,
+            )
+        except DataQualityError as exc:
+            LOGGER.warning(
+                "inspection_check_all:data_quality_error",
+                extra={**branch_log, "error": str(exc)},
+            )
+            await reporter(
+                "inspection.summary_collection:failed",
+                {"error": str(exc), "data_quality": exc.detail},
+            )
+            await websocket.send_json(
+                {
+                    "type": "error",
+                    "message": str(exc),
+                    "detail": exc.detail,
+                }
+            )
+            await websocket.close(code=1011)
+            return
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            LOGGER.exception(
+                "inspection_check_all:summary_failed",
+                extra={**branch_log, "error": str(exc)},
+            )
+            await reporter(
+                "inspection.summary_collection:failed",
+                {"error": str(exc)},
+            )
+            await websocket.send_json(
+                {
+                    "type": "error",
+                    "message": "summary collection failed",
+                    "detail": str(exc),
+                }
+            )
+            await websocket.close(code=1011)
+            return
+        if payload is None:
+            LOGGER.info("inspection_check_all:finished", extra={**branch_log, "status": None})
+            await reporter("inspection.summary_collection:finished", {"status": None})
+            await websocket.send_json({"type": "result", "mode": mode_value, "payload": None})
+            await websocket.close(code=1000)
+            return
+        payload = _prepare_summary_payload(dict(payload))
+        if collection_summary_payload:
+            meta_block = payload.get("meta")
+            if isinstance(meta_block, MutableMapping):
+                meta_block["summary_collection"] = collection_summary_payload
+        status_value = payload.get("status") if isinstance(payload, Mapping) else None
+        LOGGER.info(
+            "inspection_check_all:finished",
+            extra={**branch_log, "status": status_value},
+        )
+        await reporter(
+            "inspection.summary_collection:finished",
+            {"status": status_value, "window_hours": window_hours},
+        )
+        set_last_collection_time(collection_reference)
+        await websocket.send_json({"type": "result", "mode": mode_value, "payload": payload})
+        await websocket.close(code=1000)
+        return
+
+    symbol = target_snapshot.get("symbol") if isinstance(target_snapshot, Mapping) else None
+    if not symbol:
+        meta_block = target_snapshot.get("meta") if isinstance(target_snapshot, Mapping) else None
+        if isinstance(meta_block, Mapping):
+            symbol = meta_block.get("symbol")
+    if not symbol:
+        await websocket.send_json({"type": "error", "message": "snapshot symbol missing"})
+        await websocket.close(code=1003)
+        return
+    try:
+        session_result = await _run_session_workflow(
+            symbol,
+            now_override=now_override,
+            progress=reporter,
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging
+        LOGGER.exception(
+            "inspection_check_all:session_detailed_failed",
+            extra={**log_extra, "error": str(exc)},
+        )
+        await websocket.send_json(
+            {
+                "type": "error",
+                "message": "session collection failed",
+                "detail": str(exc),
+            }
+        )
+        await websocket.close(code=1011)
+        return
+    payload = session_result.as_dict()
+    LOGGER.info(
+        "inspection_check_all:finished",
+        extra={**log_extra, "mode": mode_value, "status": payload.get("status")},
+    )
+    await reporter(
+        "inspection.session_collection:finished",
+        {
+            "status": payload.get("status"),
+            "coverage_pct": payload.get("session", {}).get("coverage_pct"),
+        },
+    )
+    await websocket.send_json({"type": "result", "mode": mode_value, "payload": payload})
+    await websocket.close(code=1000)
 
 
 @app.get("/presets")

--- a/src/services/inspection.py
+++ b/src/services/inspection.py
@@ -1956,6 +1956,19 @@ def render_inspection_page(
       border-color: rgba(250, 204, 21, 0.6);
       background: rgba(113, 63, 18, 0.35);
     }
+    .progress-log {
+      font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, monospace;
+      background: rgba(15, 23, 42, 0.68);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      max-height: 220px;
+      overflow-y: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-size: 0.7rem;
+      line-height: 1.45;
+    }
     .preset-controls {
       margin-top: 0.8rem;
       margin-bottom: 0.8rem;
@@ -2515,6 +2528,7 @@ def render_inspection_page(
     const sessionDetailedButton = document.getElementById("btn_collect_last_session_detailed");
     const topupButton = document.getElementById("collect-topup");
     const collectSelectionButton = document.getElementById("collect-selection");
+    const progressLogEl = document.getElementById("inspection-progress-log");
     const checkAllHours = document.getElementById("checkall-hours");
     const snapshotMeta = document.getElementById("snapshot-meta");
     const chartContainer = document.getElementById("inspection-chart");
@@ -2629,6 +2643,7 @@ def render_inspection_page(
       liveFrames: {},
       liveMeta: null,
       liveMismatch: false,
+      progressEvents: [],
     };
 
     const AUTO_PRESET_SYMBOLS = new Set(["BTCUSDT", "ETHUSDT", "SOLUSDT"]);
@@ -3095,6 +3110,38 @@ def render_inspection_page(
       statusEl.hidden = !message;
     }
 
+    function resetProgressLog() {
+      if (!state) return;
+      state.progressEvents = [];
+      if (progressLogEl) {
+        progressLogEl.textContent = "";
+      }
+    }
+
+    function appendProgress(eventName, data = {}) {
+      if (!state) return;
+      if (!Array.isArray(state.progressEvents)) {
+        state.progressEvents = [];
+      }
+      const timestamp = new Date().toISOString();
+      const entry = { ts: timestamp, event: eventName, data };
+      state.progressEvents.push(entry);
+      if (state.progressEvents.length > 200) {
+        state.progressEvents.shift();
+      }
+      if (progressLogEl) {
+        const clock = timestamp.substring(11, 19);
+        const details = data && Object.keys(data).length ? ` ${JSON.stringify(data)}` : "";
+        const line = `[${clock}] ${eventName}${details}`;
+        if (progressLogEl.textContent) {
+          progressLogEl.textContent += `\n${line}`;
+        } else {
+          progressLogEl.textContent = line;
+        }
+        progressLogEl.scrollTop = progressLogEl.scrollHeight;
+      }
+    }
+
     function updateSelectionLabel() {
       const start = state.selection && state.selection.start;
       const end = state.selection && state.selection.end;
@@ -3353,58 +3400,300 @@ def render_inspection_page(
         ? Math.max(1, Math.floor(lookbackDaysRaw))
         : 3;
       const mode = typeof options?.mode === "string" ? options.mode : "summary";
+      const progressFn = typeof options?.progress === "function" ? options.progress : null;
+      const notifyProgress = (eventName, data = {}) => {
+        if (!progressFn) return;
+        try {
+          const result = progressFn(eventName, data);
+          if (result && typeof result.then === "function") {
+            result.catch((error) => console.warn("progress callback failed", error));
+          }
+        } catch (error) {
+          console.warn("progress callback failed", error);
+        }
+      };
+      const measureNow = () =>
+        typeof performance !== "undefined" && typeof performance.now === "function"
+          ? performance.now()
+          : Date.now();
+
       const symbol = activeSymbol();
       if (!symbol) {
         throw new Error("live-snapshot-symbol-missing");
       }
-      const liveMeta = resolveLiveMetaSnapshot();
-      const endMs = resolveLiveRangeEndMs(liveMeta);
-      const lookbackMs = lookbackDays * 24 * 60 * 60 * 1000;
-      const startMs = Math.max(0, Math.floor(endMs - lookbackMs));
-      const rawCandles = await fetchCandles(symbol, "1m", startMs, endMs, { limit: 1500 });
-      const candles = normaliseSnapshotCandles(rawCandles);
-      if (!candles.length) {
-        throw new Error("live-snapshot-empty");
-      }
-      const frames = { "1m": { tf: "1m", candles } };
-      const metaBlock = {
-        source: {
-          kind: "live-store",
+      try {
+        const liveMeta = resolveLiveMetaSnapshot();
+        const endMs = resolveLiveRangeEndMs(liveMeta);
+        const lookbackMs = lookbackDays * 24 * 60 * 60 * 1000;
+        const startMs = Math.max(0, Math.floor(endMs - lookbackMs));
+
+        notifyProgress("client.capture_live:preflight", {
           mode,
+          symbol,
+          start_ms: startMs,
+          end_ms: endMs,
           lookback_days: lookbackDays,
-          captured_at: new Date().toISOString(),
-        },
-        requested: {
-          frames: Object.keys(frames),
-          lookback_days: lookbackDays,
-        },
-      };
-      if (liveMeta) {
-        const livePayload = {
-          last_price: Number.isFinite(liveMeta.last_price) ? Number(liveMeta.last_price) : null,
-          last_tf: liveMeta.last_tf || "1m",
-          last_ts_ms: Number.isFinite(liveMeta.last_ts_ms) ? Number(liveMeta.last_ts_ms) : null,
-          age_sec: Number.isFinite(liveMeta.age_sec) ? Number(liveMeta.age_sec) : null,
-          stale: Boolean(liveMeta.stale),
-          mismatch: Boolean(liveMeta.mismatch),
+        });
+
+        const fetchStarted = measureNow();
+        notifyProgress("client.capture_live:fetch_start", {
+          symbol,
+          start_ms: startMs,
+          end_ms: endMs,
+          limit: 1500,
+        });
+        let rawCandles;
+        try {
+          rawCandles = await fetchCandles(symbol, "1m", startMs, endMs, { limit: 1500 });
+        } catch (error) {
+          notifyProgress("client.capture_live:fetch_error", {
+            message: error?.message || String(error),
+          });
+          throw error;
+        }
+        const fetchDuration = Math.round(measureNow() - fetchStarted);
+        const rawCount = Array.isArray(rawCandles) ? rawCandles.length : 0;
+        notifyProgress("client.capture_live:fetched", {
+          candles: rawCount,
+          duration_ms: fetchDuration,
+        });
+
+        const candles = normaliseSnapshotCandles(rawCandles);
+        if (!candles.length) {
+          notifyProgress("client.capture_live:empty", { raw_candles: rawCount });
+          throw new Error("live-snapshot-empty");
+        }
+        notifyProgress("client.capture_live:normalised", {
+          candles: candles.length,
+          removed: Math.max(0, rawCount - candles.length),
+        });
+
+        const frames = { "1m": { tf: "1m", candles } };
+        const metaBlock = {
+          source: {
+            kind: "live-store",
+            mode,
+            lookback_days: lookbackDays,
+            captured_at: new Date().toISOString(),
+          },
+          requested: {
+            frames: Object.keys(frames),
+            lookback_days: lookbackDays,
+          },
         };
-        metaBlock.live = livePayload;
-        metaBlock.stream = livePayload;
-        metaBlock.live_price = livePayload;
+        if (liveMeta) {
+          const livePayload = {
+            last_price: Number.isFinite(liveMeta.last_price) ? Number(liveMeta.last_price) : null,
+            last_tf: liveMeta.last_tf || "1m",
+            last_ts_ms: Number.isFinite(liveMeta.last_ts_ms) ? Number(liveMeta.last_ts_ms) : null,
+            age_sec: Number.isFinite(liveMeta.age_sec) ? Number(liveMeta.age_sec) : null,
+            stale: Boolean(liveMeta.stale),
+            mismatch: Boolean(liveMeta.mismatch),
+          };
+          metaBlock.live = livePayload;
+          metaBlock.stream = livePayload;
+          metaBlock.live_price = livePayload;
+        }
+        const payload = {
+          symbol,
+          tf: "1m",
+          candles,
+          frames,
+          meta: metaBlock,
+          lookback_days: lookbackDays,
+        };
+
+        notifyProgress("client.capture_live:registering", {
+          candles: candles.length,
+        });
+        const registerStarted = measureNow();
+        const result = await postSnapshot(payload);
+        const registerDuration = Math.round(measureNow() - registerStarted);
+        if (!result || !result.snapshot_id) {
+          notifyProgress("client.capture_live:register_error", {
+            duration_ms: registerDuration,
+          });
+          throw new Error("live-snapshot-registration-failed");
+        }
+        notifyProgress("client.capture_live:registered", {
+          snapshot_id: result.snapshot_id,
+          duration_ms: registerDuration,
+        });
+        return { snapshotId: result.snapshot_id, payload };
+      } catch (error) {
+        notifyProgress("client.capture_live:error", {
+          message: error?.message || String(error),
+        });
+        throw error;
       }
-      const payload = {
-        symbol,
-        tf: "1m",
-        candles,
-        frames,
-        meta: metaBlock,
-        lookback_days: lookbackDays,
-      };
-      const result = await postSnapshot(payload);
-      if (!result || !result.snapshot_id) {
-        throw new Error("live-snapshot-registration-failed");
-      }
-      return { snapshotId: result.snapshot_id, payload };
+    }
+
+    function websocketUrl(path = "") {
+      const scheme = window.location.protocol === "https:" ? "wss" : "ws";
+      const normalisedPath = path.startsWith("/") ? path : `/${path}`;
+      return `${scheme}://${window.location.host}${normalisedPath}`;
+    }
+
+    function openCollectionChannel({ mode, summaryDays }) {
+      return new Promise((resolve, reject) => {
+        const url = websocketUrl("/inspection/ws/progress");
+        appendProgress("client.connecting", { mode, url });
+        const socket = new WebSocket(url);
+        let ready = false;
+        let closedByClient = false;
+        let started = false;
+        let startResolver = null;
+        let startRejecter = null;
+        let startSettled = false;
+
+        const settleStartSuccess = (value) => {
+          if (startResolver) {
+            startResolver(value);
+          }
+          startResolver = null;
+          startRejecter = null;
+          startSettled = true;
+        };
+
+        const settleStartFailure = (error) => {
+          if (startRejecter) {
+            startRejecter(error);
+          }
+          startResolver = null;
+          startRejecter = null;
+          startSettled = true;
+        };
+
+        const channel = {
+          sendProgress(eventName, data = {}) {
+            if (!eventName || socket.readyState !== WebSocket.OPEN) {
+              return;
+            }
+            const payload = {
+              type: "client_progress",
+              event: String(eventName),
+              data: data && typeof data === "object" ? data : { value: data },
+            };
+            try {
+              socket.send(JSON.stringify(payload));
+            } catch (error) {
+              console.warn("Не удалось отправить клиентский прогресс", error);
+            }
+          },
+          start({ snapshotId, summaryDays: overrideDays } = {}) {
+            if (started) {
+              throw new Error("collection_already_started");
+            }
+            if (!snapshotId) {
+              throw new Error("snapshot_required");
+            }
+            if (socket.readyState !== WebSocket.OPEN) {
+              throw new Error("ws_not_ready");
+            }
+            started = true;
+            startSettled = false;
+            const message = {
+              type: "start",
+              mode,
+              snapshot: snapshotId,
+            };
+            const summaryValue = Number.isFinite(overrideDays)
+              ? Number(overrideDays)
+              : Number.isFinite(summaryDays)
+              ? Number(summaryDays)
+              : null;
+            if (mode === "summary" && Number.isFinite(summaryValue)) {
+              message.summary_days = Number(summaryValue);
+            }
+            socket.send(JSON.stringify(message));
+            return new Promise((resolveStart, rejectStart) => {
+              startResolver = resolveStart;
+              startRejecter = rejectStart;
+            });
+          },
+          close(code = 1000) {
+            closedByClient = true;
+            try {
+              socket.close(code);
+            } catch (closeError) {
+              console.debug("ws close error", closeError);
+            }
+          },
+        };
+
+        socket.addEventListener("open", () => {
+          ready = true;
+          appendProgress("client.open", { mode });
+          const payload = { type: "prepare", mode };
+          if (mode === "summary" && Number.isFinite(summaryDays)) {
+            payload.summary_days = Number(summaryDays);
+          }
+          socket.send(JSON.stringify(payload));
+          resolve(channel);
+        });
+
+        socket.addEventListener("message", (event) => {
+          let parsed;
+          try {
+            parsed = JSON.parse(event.data);
+          } catch (parseError) {
+            appendProgress("client.message_parse_error", { raw: String(event.data).slice(0, 200) });
+            return;
+          }
+          if (parsed.type === "progress") {
+            appendProgress(parsed.event || "progress", parsed.data || {});
+            return;
+          }
+          if (parsed.type === "ack") {
+            appendProgress(parsed.event || "ack", parsed.data || {});
+            return;
+          }
+          if (parsed.type === "result") {
+            appendProgress("client.result", { mode: parsed.mode || mode });
+            settleStartSuccess(parsed.payload);
+            return;
+          }
+          if (parsed.type === "error") {
+            appendProgress("client.error", { message: parsed.message, detail: parsed.detail });
+            const error = new Error(parsed.message || "ws-error");
+            if (parsed.detail !== undefined) {
+              error.detail = parsed.detail;
+            }
+            if (!started) {
+              reject(error);
+            } else {
+              settleStartFailure(error);
+            }
+            return;
+          }
+          appendProgress("client.message", parsed);
+        });
+
+        socket.addEventListener("error", () => {
+          appendProgress("client.socket_error");
+          const error = new Error("ws-error");
+          if (!ready) {
+            reject(error);
+          } else if (started && !startSettled) {
+            settleStartFailure(error);
+          }
+        });
+
+        socket.addEventListener("close", (event) => {
+          appendProgress("client.close", { code: event.code, reason: event.reason || "" });
+          if (closedByClient) {
+            return;
+          }
+          const error = new Error(`ws-closed-${event.code}`);
+          if (!ready) {
+            reject(error);
+            return;
+          }
+          if (started && !startSettled) {
+            settleStartFailure(error);
+          }
+        });
+      });
     }
 
     async function requestSummaryData() {
@@ -3413,10 +3702,35 @@ def render_inspection_page(
       }
 
       let createdSnapshotId = null;
+      let channel = null;
+
+      const closeChannel = (code = 1000) => {
+        if (!channel) return;
+        try {
+          channel.close(code);
+        } catch (error) {
+          console.debug("ws close error", error);
+        }
+        channel = null;
+      };
 
       try {
         updateStatus("Собираем лайв-данные за последние 3 дня...", "info");
-        const { snapshotId } = await captureLiveSnapshot({ lookbackDays: 3, mode: "summary" });
+        resetProgressLog();
+        channel = await openCollectionChannel({ mode: "summary", summaryDays: 3 });
+        const report = (eventName, data = {}) => {
+          appendProgress(eventName, data);
+          if (channel) {
+            channel.sendProgress(eventName, data);
+          }
+        };
+        report("client.flow:channel_ready", { mode: "summary" });
+        report("client.flow:capture_snapshot", { mode: "summary" });
+        const { snapshotId } = await captureLiveSnapshot({
+          lookbackDays: 3,
+          mode: "summary",
+          progress: report,
+        });
         createdSnapshotId = snapshotId;
         state.snapshotId = snapshotId;
         updateCheckAllState();
@@ -3426,33 +3740,32 @@ def render_inspection_page(
         if (snapshotSelect) {
           snapshotSelect.value = snapshotId;
         }
-        const url = new URL("/inspection/check-all", window.location.origin);
-        url.searchParams.set("snapshot", snapshotId);
-        url.searchParams.set("mode", "summary");
-        url.searchParams.set("summary_days", "3");
-        const response = await fetch(url.toString(), {
-          headers: { Accept: "application/json" },
-          cache: "no-store",
-        });
-        if (response.status === 204) {
+        report("client.flow:server_start", { snapshot: snapshotId, summary_days: 3 });
+        const payload = await channel.start({ snapshotId, summaryDays: 3 });
+        if (!payload) {
           state.checkAll = null;
           setJson(checkAllPre, null);
           updateStatus("Не удалось собрать 3-дневный контекст", "warning");
+          report("client.flow:server_empty", { snapshot: snapshotId });
           return;
         }
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-        const payload = await response.json();
         state.checkAll = payload;
         setJson(checkAllPre, payload);
         updateStatus("3-дневный контекст готов", "success");
+        report("client.flow:completed", { status: payload?.status ?? null });
       } catch (error) {
         console.error(error);
+        if (channel) {
+          channel.sendProgress("client.flow:error", {
+            message: error?.message || String(error),
+          });
+        }
         state.checkAll = null;
         setJson(checkAllPre, null);
-        updateStatus("Ошибка при сборе 3-дневного контекста", "error");
+        const detail = error && typeof error.detail !== "undefined" ? `: ${JSON.stringify(error.detail)}` : "";
+        updateStatus(`Ошибка при сборе 3-дневного контекста${detail}`, "error");
       } finally {
+        closeChannel();
         if (summaryButton) {
           summaryButton.disabled = false;
         }
@@ -3471,10 +3784,35 @@ def render_inspection_page(
       }
 
       let createdSnapshotId = null;
+      let channel = null;
+
+      const closeChannel = (code = 1000) => {
+        if (!channel) return;
+        try {
+          channel.close(code);
+        } catch (error) {
+          console.debug("ws close error", error);
+        }
+        channel = null;
+      };
 
       try {
         updateStatus("Собираем подробные данные по последней сессии...", "info");
-        const { snapshotId } = await captureLiveSnapshot({ lookbackDays: 1, mode: "session_detailed" });
+        resetProgressLog();
+        channel = await openCollectionChannel({ mode: "session_detailed" });
+        const report = (eventName, data = {}) => {
+          appendProgress(eventName, data);
+          if (channel) {
+            channel.sendProgress(eventName, data);
+          }
+        };
+        report("client.flow:channel_ready", { mode: "session_detailed" });
+        report("client.flow:capture_snapshot", { mode: "session_detailed" });
+        const { snapshotId } = await captureLiveSnapshot({
+          lookbackDays: 1,
+          mode: "session_detailed",
+          progress: report,
+        });
         createdSnapshotId = snapshotId;
         state.snapshotId = snapshotId;
         updateCheckAllState();
@@ -3484,32 +3822,32 @@ def render_inspection_page(
         if (snapshotSelect) {
           snapshotSelect.value = snapshotId;
         }
-        const url = new URL("/inspection/check-all", window.location.origin);
-        url.searchParams.set("snapshot", snapshotId);
-        url.searchParams.set("mode", "session_detailed");
-        const response = await fetch(url.toString(), {
-          headers: { Accept: "application/json" },
-          cache: "no-store",
-        });
-        if (response.status === 204) {
+        report("client.flow:server_start", { snapshot: snapshotId, mode: "session_detailed" });
+        const payload = await channel.start({ snapshotId });
+        if (!payload) {
           state.checkAll = null;
           setJson(checkAllPre, null);
           updateStatus("Не удалось собрать данные по последней сессии", "warning");
+          report("client.flow:server_empty", { snapshot: snapshotId });
           return;
         }
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-        const payload = await response.json();
         state.checkAll = payload;
         setJson(checkAllPre, payload);
         updateStatus("Сессионный отчёт готов", "success");
+        report("client.flow:completed", { status: payload?.status ?? null });
       } catch (error) {
         console.error(error);
+        if (channel) {
+          channel.sendProgress("client.flow:error", {
+            message: error?.message || String(error),
+          });
+        }
         state.checkAll = null;
         setJson(checkAllPre, null);
-        updateStatus("Ошибка при сборе данных по последней сессии", "error");
+        const detail = error && typeof error.detail !== "undefined" ? `: ${JSON.stringify(error.detail)}` : "";
+        updateStatus(`Ошибка при сборе данных по последней сессии${detail}`, "error");
       } finally {
+        closeChannel();
         if (sessionDetailedButton) {
           sessionDetailedButton.disabled = false;
         }
@@ -3531,6 +3869,8 @@ def render_inspection_page(
 
       try {
         updateStatus("Дособираем свежие лайв-данные...", "info");
+        resetProgressLog();
+        appendProgress("client.capture_snapshot", { mode: "topup" });
         const { snapshotId } = await captureLiveSnapshot({ lookbackDays: 1, mode: "topup" });
         createdSnapshotId = snapshotId;
         state.snapshotId = snapshotId;
@@ -3541,6 +3881,7 @@ def render_inspection_page(
         if (snapshotSelect) {
           snapshotSelect.value = snapshotId;
         }
+        appendProgress("client.http_request", { mode: "topup" });
         const url = new URL("/inspection/check-all", window.location.origin);
         url.searchParams.set("snapshot", snapshotId);
         url.searchParams.set("mode", "topup");
@@ -4362,6 +4703,7 @@ def render_inspection_page(
               <button id=\"collect-selection\" class=\"secondary\" type=\"button\" disabled>Собрать информацию за выбранный период</button>
             </div>
             <div class=\"status-banner\" id=\"inspection-status\" hidden data-tone=\"info\"></div>
+            <div class=\"progress-log\" id=\"inspection-progress-log\" aria-live=\"polite\"></div>
             <div class=\"preset-chip-bar\">
               <span id=\"preset-chip\" class=\"preset-chip\" hidden></span>
             </div>

--- a/src/services/progress.py
+++ b/src/services/progress.py
@@ -1,0 +1,30 @@
+"""Utilities for streaming detailed progress updates to clients."""
+from __future__ import annotations
+
+from inspect import isawaitable
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+ProgressPayload = Dict[str, Any]
+ProgressReporter = Callable[[str, ProgressPayload], Awaitable[None] | None]
+
+
+async def emit_progress(
+    reporter: Optional[ProgressReporter],
+    event: str,
+    /,
+    **payload: Any,
+) -> None:
+    """Dispatch a progress event if a reporter callback is provided."""
+
+    if reporter is None:
+        return
+
+    message: ProgressPayload = dict(payload)
+    try:
+        result = reporter(event, message)
+    except Exception:  # pragma: no cover - defensive guard
+        return
+    if result is None:
+        return
+    if isawaitable(result):
+        await result

--- a/src/services/session_collector.py
+++ b/src/services/session_collector.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, time as dtime, timedelta, timezone
-from typing import Any, Dict, Mapping, MutableMapping
+from typing import Any, Dict, Mapping, MutableMapping, Optional
 
 from . import tracing
+from .progress import ProgressReporter, emit_progress
 
 TRACE_LOGGER = tracing.LOGGER.getChild("session_collector")
 
@@ -156,7 +157,11 @@ def _resolve_session_window(now_utc: datetime) -> SessionWindow:
     )
 
 
-async def collect_last_session_detailed(symbol: str, now: datetime | None = None) -> SessionCollectionResult:
+async def collect_last_session_detailed(
+    symbol: str,
+    now: datetime | None = None,
+    progress: Optional[ProgressReporter] = None,
+) -> SessionCollectionResult:
     """Collect detailed data for the latest trading session.
 
     Current implementation returns a placeholder payload marking the session as insufficient
@@ -171,6 +176,12 @@ async def collect_last_session_detailed(symbol: str, now: datetime | None = None
             "requested_at": now_dt.isoformat(),
         },
     )
+    await emit_progress(
+        progress,
+        "session_collector:start",
+        symbol=symbol,
+        requested_at=now_dt.isoformat(),
+    )
     session_window = _resolve_session_window(now_dt)
     TRACE_LOGGER.debug(
         "session_collector:resolved_window",
@@ -181,6 +192,15 @@ async def collect_last_session_detailed(symbol: str, now: datetime | None = None
             "close_utc": session_window.close_utc.isoformat(),
             "active": session_window.is_active,
         },
+    )
+    await emit_progress(
+        progress,
+        "session_collector:resolved_window",
+        symbol=symbol,
+        session=session_window.name,
+        open_utc=session_window.open_utc.isoformat(),
+        close_utc=session_window.close_utc.isoformat(),
+        active=session_window.is_active,
     )
     missing_fields = (
         "ohlcv.coverage",
@@ -205,6 +225,14 @@ async def collect_last_session_detailed(symbol: str, now: datetime | None = None
             "coverage_pct": result.coverage_pct,
             "missing_fields": list(result.missing_fields),
         },
+    )
+    await emit_progress(
+        progress,
+        "session_collector:finished",
+        symbol=symbol,
+        status=result.status,
+        coverage_pct=result.coverage_pct,
+        missing_fields=list(result.missing_fields),
     )
 
     return result

--- a/src/services/session_collector.py
+++ b/src/services/session_collector.py
@@ -5,6 +5,10 @@ from dataclasses import dataclass
 from datetime import datetime, time as dtime, timedelta, timezone
 from typing import Any, Dict, Mapping, MutableMapping
 
+from . import tracing
+
+TRACE_LOGGER = tracing.LOGGER.getChild("session_collector")
+
 try:
     from zoneinfo import ZoneInfo
 except ImportError:  # pragma: no cover - Python <3.9 fallback
@@ -160,7 +164,24 @@ async def collect_last_session_detailed(symbol: str, now: datetime | None = None
     """
 
     now_dt = now.astimezone(timezone.utc) if isinstance(now, datetime) else datetime.now(timezone.utc)
+    TRACE_LOGGER.debug(
+        "session_collector:start",
+        extra={
+            "symbol": symbol,
+            "requested_at": now_dt.isoformat(),
+        },
+    )
     session_window = _resolve_session_window(now_dt)
+    TRACE_LOGGER.debug(
+        "session_collector:resolved_window",
+        extra={
+            "symbol": symbol,
+            "session": session_window.name,
+            "open_utc": session_window.open_utc.isoformat(),
+            "close_utc": session_window.close_utc.isoformat(),
+            "active": session_window.is_active,
+        },
+    )
     missing_fields = (
         "ohlcv.coverage",
         "orderflow.coverage",
@@ -168,11 +189,23 @@ async def collect_last_session_detailed(symbol: str, now: datetime | None = None
         "orderflow.cvd",
         "orderflow.footprint",
     )
-    return SessionCollectionResult(
+    result = SessionCollectionResult(
         symbol=symbol,
         status="insufficient_data",
         session=session_window,
         coverage_pct=0.0,
         missing_fields=missing_fields,
     )
+
+    TRACE_LOGGER.debug(
+        "session_collector:finished",
+        extra={
+            "symbol": symbol,
+            "status": result.status,
+            "coverage_pct": result.coverage_pct,
+            "missing_fields": list(result.missing_fields),
+        },
+    )
+
+    return result
 

--- a/src/services/summary_collector.py
+++ b/src/services/summary_collector.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 import httpx
 
+from . import tracing
 from .candles_repository import CandleRepository, UpsertStats, get_repository
 from .ohlc_sanitizer import sanitize_candles
 from .ohlc import TIMEFRAME_TO_MS
@@ -18,6 +19,7 @@ from .timeutils import ensure_ms_epoch
 from .check_all_datas import _normalise_binance_row
 
 LOGGER = logging.getLogger(__name__)
+TRACE_LOGGER = tracing.LOGGER.getChild("summary_collector")
 UTC = timezone.utc
 
 BINANCE_ENDPOINT = "https://fapi.binance.com/fapi/v1/klines"
@@ -197,6 +199,18 @@ async def _upsert_sanitised(
     if not candles:
         return UpsertStats(written=0, dropped_ts=0, dropped_ohlc=0), []
     sanitised = sanitize_candles(candles, stage=stage)
+    TRACE_LOGGER.debug(
+        "summary_collector:upsert_sanitised",
+        extra={
+            "symbol": symbol,
+            "interval": interval,
+            "stage": stage,
+            "incoming": len(candles),
+            "sanitised": len(sanitised.candles),
+            "dropped_ts": getattr(sanitised, "invalid_ts", 0),
+            "dropped_ohlc": getattr(sanitised, "invalid_ohlc", 0),
+        },
+    )
     stats = await asyncio.to_thread(
         repository.upsert_candles,
         symbol,
@@ -289,6 +303,19 @@ async def _fill_gap(
             candle["t"] = aligned
             normalised.append(candle)
 
+        TRACE_LOGGER.debug(
+            "summary_collector:normalised_batch",
+            extra={
+                "symbol": symbol,
+                "interval": interval,
+                "gap_start": gap_start,
+                "gap_end": gap_end,
+                "requested_limit": page_limit,
+                "raw_rows": len(raw_rows),
+                "normalised_rows": len(normalised),
+            },
+        )
+
         if not normalised:
             cursor += page_span
             continue
@@ -297,6 +324,16 @@ async def _fill_gap(
         for candle in normalised:
             dedup[int(candle["t"])] = candle
         normalised = [dedup[key] for key in sorted(dedup.keys())]
+        TRACE_LOGGER.debug(
+            "summary_collector:deduplicated_batch",
+            extra={
+                "symbol": symbol,
+                "interval": interval,
+                "gap_start": gap_start,
+                "gap_end": gap_end,
+                "deduped_rows": len(normalised),
+            },
+        )
         stats, sanitised = await _upsert_sanitised(
             repository,
             symbol=symbol,
@@ -307,6 +344,17 @@ async def _fill_gap(
         written += stats.written
         dropped_ts += stats.dropped_ts
         dropped_ohlc += stats.dropped_ohlc
+
+        TRACE_LOGGER.debug(
+            "summary_collector:batch_persisted",
+            extra={
+                "symbol": symbol,
+                "interval": interval,
+                "written": stats.written,
+                "dropped_ts": stats.dropped_ts,
+                "dropped_ohlc": stats.dropped_ohlc,
+            },
+        )
 
         if not sanitised:
             cursor += page_span
@@ -322,7 +370,31 @@ async def _fill_gap(
         )
         cursor = last_open + interval_ms
 
+        TRACE_LOGGER.debug(
+            "summary_collector:gap_progress_updated",
+            extra={
+                "symbol": symbol,
+                "interval": interval,
+                "gap_start": gap_start,
+                "last_open": last_open,
+            },
+        )
+
     await asyncio.to_thread(repository.clear_gap_progress, symbol, interval, gap_start)
+
+    TRACE_LOGGER.debug(
+        "summary_collector:gap_completed",
+        extra={
+            "symbol": symbol,
+            "interval": interval,
+            "gap_start": gap_start,
+            "gap_end": gap_end,
+            "written": written,
+            "dropped_ts": dropped_ts,
+            "dropped_ohlc": dropped_ohlc,
+            "requests": requests,
+        },
+    )
 
     return IntervalSummary(
         gaps_total=1,
@@ -359,6 +431,16 @@ async def collect_recent_summary(
     if start_ms > now_ms:
         start_ms = now_ms
 
+    TRACE_LOGGER.debug(
+        "summary_collector:start",
+        extra={
+            "symbol": symbol,
+            "start_ms": start_ms,
+            "end_ms": now_ms,
+            "days": span_days,
+        },
+    )
+
     target_intervals = list(intervals or TIMEFRAME_TO_MS.keys())
     summaries: Dict[str, IntervalSummary] = {}
     total_requests = 0
@@ -391,6 +473,15 @@ async def collect_recent_summary(
                     requests=0,
                     remaining_gaps=[],
                 )
+                TRACE_LOGGER.debug(
+                    "summary_collector:interval_skipped",
+                    extra={
+                        "symbol": symbol,
+                        "interval": interval,
+                        "first_expected": first_expected,
+                        "last_closed": last_closed,
+                    },
+                )
                 continue
             existing = await _fetch_existing(
                 repo,
@@ -399,7 +490,27 @@ async def collect_recent_summary(
                 start_ms=first_expected,
                 end_ms=last_closed,
             )
+            TRACE_LOGGER.debug(
+                "summary_collector:fetched_existing",
+                extra={
+                    "symbol": symbol,
+                    "interval": interval,
+                    "first_expected": first_expected,
+                    "last_closed": last_closed,
+                    "existing": len(existing),
+                },
+            )
             gaps = _compute_gaps(first_expected, last_closed, interval_ms, existing)
+            TRACE_LOGGER.debug(
+                "summary_collector:computed_gaps",
+                extra={
+                    "symbol": symbol,
+                    "interval": interval,
+                    "gap_count": len(gaps),
+                    "first_expected": first_expected,
+                    "last_closed": last_closed,
+                },
+            )
             if not gaps:
                 summaries[interval] = IntervalSummary(
                     gaps_total=0,
@@ -426,6 +537,17 @@ async def collect_recent_summary(
                 total_requests += summary.requests
                 total_written += summary.candles_written
                 total_dropped += summary.dropped_candles
+                TRACE_LOGGER.debug(
+                    "summary_collector:interval_progress",
+                    extra={
+                        "symbol": symbol,
+                        "interval": interval,
+                        "gap_from": gap.get("from"),
+                        "gap_to": gap.get("to"),
+                        "written_total": total_written,
+                        "requests_total": total_requests,
+                    },
+                )
 
             refreshed = await _fetch_existing(
                 repo,
@@ -443,8 +565,20 @@ async def collect_recent_summary(
                 requests=sum(item.requests for item in gap_summaries),
                 remaining_gaps=remaining,
             )
+            TRACE_LOGGER.debug(
+                "summary_collector:interval_finished",
+                extra={
+                    "symbol": symbol,
+                    "interval": interval,
+                    "gaps_total": len(gaps),
+                    "candles_written": summaries[interval].candles_written,
+                    "dropped_candles": summaries[interval].dropped_candles,
+                    "requests": summaries[interval].requests,
+                    "remaining_gaps": len(remaining),
+                },
+            )
 
-    return CollectionSummary(
+    summary = CollectionSummary(
         symbol=symbol.upper(),
         start_ms=start_ms,
         end_ms=now_ms,
@@ -453,6 +587,18 @@ async def collect_recent_summary(
         candles_written=total_written,
         dropped_candles=total_dropped,
     )
+
+    TRACE_LOGGER.debug(
+        "summary_collector:finished",
+        extra={
+            "symbol": summary.symbol,
+            "requests": summary.requests,
+            "candles_written": summary.candles_written,
+            "dropped_candles": summary.dropped_candles,
+        },
+    )
+
+    return summary
 
 
 __all__ = ["collect_recent_summary", "CollectionSummary"]

--- a/src/services/summary_collector.py
+++ b/src/services/summary_collector.py
@@ -17,6 +17,7 @@ from .ohlc_sanitizer import sanitize_candles
 from .ohlc import TIMEFRAME_TO_MS
 from .timeutils import ensure_ms_epoch
 from .check_all_datas import _normalise_binance_row
+from .progress import ProgressReporter, emit_progress
 
 LOGGER = logging.getLogger(__name__)
 TRACE_LOGGER = tracing.LOGGER.getChild("summary_collector")
@@ -247,17 +248,18 @@ async def _fill_gap(
     interval_ms: int,
     client: httpx.AsyncClient,
     bucket: _TokenBucket,
+    progress: Optional[ProgressReporter] = None,
 ) -> IntervalSummary:
     gap_start = int(gap["from"])
     gap_end = int(gap["to"])
-    progress = await asyncio.to_thread(
+    resume_marker = await asyncio.to_thread(
         repository.load_gap_progress,
         symbol,
         interval,
         gap_start,
     )
-    if progress is not None:
-        resume_from = max(gap_start, progress + interval_ms)
+    if resume_marker is not None:
+        resume_from = max(gap_start, resume_marker + interval_ms)
     else:
         resume_from = gap_start
 
@@ -267,6 +269,16 @@ async def _fill_gap(
     dropped_ts = 0
     dropped_ohlc = 0
     requests = 0
+
+    await emit_progress(
+        progress,
+        "summary_collector:gap_begin",
+        symbol=symbol,
+        interval=interval,
+        gap_start=gap_start,
+        gap_end=gap_end,
+        resume_from=resume_from,
+    )
 
     while cursor <= gap_end:
         page_end = min(gap_end, cursor + page_span - interval_ms)
@@ -315,6 +327,17 @@ async def _fill_gap(
                 "normalised_rows": len(normalised),
             },
         )
+        await emit_progress(
+            progress,
+            "summary_collector:normalised_batch",
+            symbol=symbol,
+            interval=interval,
+            gap_start=gap_start,
+            gap_end=gap_end,
+            requested_limit=page_limit,
+            raw_rows=len(raw_rows),
+            normalised_rows=len(normalised),
+        )
 
         if not normalised:
             cursor += page_span
@@ -333,6 +356,15 @@ async def _fill_gap(
                 "gap_end": gap_end,
                 "deduped_rows": len(normalised),
             },
+        )
+        await emit_progress(
+            progress,
+            "summary_collector:deduplicated_batch",
+            symbol=symbol,
+            interval=interval,
+            gap_start=gap_start,
+            gap_end=gap_end,
+            deduped_rows=len(normalised),
         )
         stats, sanitised = await _upsert_sanitised(
             repository,
@@ -354,6 +386,15 @@ async def _fill_gap(
                 "dropped_ts": stats.dropped_ts,
                 "dropped_ohlc": stats.dropped_ohlc,
             },
+        )
+        await emit_progress(
+            progress,
+            "summary_collector:batch_persisted",
+            symbol=symbol,
+            interval=interval,
+            written=stats.written,
+            dropped_ts=stats.dropped_ts,
+            dropped_ohlc=stats.dropped_ohlc,
         )
 
         if not sanitised:
@@ -379,6 +420,14 @@ async def _fill_gap(
                 "last_open": last_open,
             },
         )
+        await emit_progress(
+            progress,
+            "summary_collector:gap_progress_updated",
+            symbol=symbol,
+            interval=interval,
+            gap_start=gap_start,
+            last_open=last_open,
+        )
 
     await asyncio.to_thread(repository.clear_gap_progress, symbol, interval, gap_start)
 
@@ -394,6 +443,18 @@ async def _fill_gap(
             "dropped_ohlc": dropped_ohlc,
             "requests": requests,
         },
+    )
+    await emit_progress(
+        progress,
+        "summary_collector:gap_completed",
+        symbol=symbol,
+        interval=interval,
+        gap_start=gap_start,
+        gap_end=gap_end,
+        written=written,
+        dropped_ts=dropped_ts,
+        dropped_ohlc=dropped_ohlc,
+        requests=requests,
     )
 
     return IntervalSummary(
@@ -414,6 +475,7 @@ async def collect_recent_summary(
     intervals: Optional[Sequence[str]] = None,
     repository: Optional[CandleRepository] = None,
     start_ms: Optional[int] = None,
+    progress: Optional[ProgressReporter] = None,
 ) -> CollectionSummary:
     """Ensure recent OHLC coverage exists for the requested symbol."""
 
@@ -439,6 +501,14 @@ async def collect_recent_summary(
             "end_ms": now_ms,
             "days": span_days,
         },
+    )
+    await emit_progress(
+        progress,
+        "summary_collector:start",
+        symbol=symbol,
+        start_ms=start_ms,
+        end_ms=now_ms,
+        days=span_days,
     )
 
     target_intervals = list(intervals or TIMEFRAME_TO_MS.keys())
@@ -482,6 +552,14 @@ async def collect_recent_summary(
                         "last_closed": last_closed,
                     },
                 )
+                await emit_progress(
+                    progress,
+                    "summary_collector:interval_skipped",
+                    symbol=symbol,
+                    interval=interval,
+                    first_expected=first_expected,
+                    last_closed=last_closed,
+                )
                 continue
             existing = await _fetch_existing(
                 repo,
@@ -500,6 +578,15 @@ async def collect_recent_summary(
                     "existing": len(existing),
                 },
             )
+            await emit_progress(
+                progress,
+                "summary_collector:fetched_existing",
+                symbol=symbol,
+                interval=interval,
+                first_expected=first_expected,
+                last_closed=last_closed,
+                existing=len(existing),
+            )
             gaps = _compute_gaps(first_expected, last_closed, interval_ms, existing)
             TRACE_LOGGER.debug(
                 "summary_collector:computed_gaps",
@@ -511,6 +598,15 @@ async def collect_recent_summary(
                     "last_closed": last_closed,
                 },
             )
+            await emit_progress(
+                progress,
+                "summary_collector:computed_gaps",
+                symbol=symbol,
+                interval=interval,
+                gap_count=len(gaps),
+                first_expected=first_expected,
+                last_closed=last_closed,
+            )
             if not gaps:
                 summaries[interval] = IntervalSummary(
                     gaps_total=0,
@@ -519,6 +615,14 @@ async def collect_recent_summary(
                     dropped_candles=0,
                     requests=0,
                     remaining_gaps=[],
+                )
+                await emit_progress(
+                    progress,
+                    "summary_collector:interval_complete",
+                    symbol=symbol,
+                    interval=interval,
+                    first_expected=first_expected,
+                    last_closed=last_closed,
                 )
                 continue
 
@@ -532,6 +636,7 @@ async def collect_recent_summary(
                     interval_ms=interval_ms,
                     client=client,
                     bucket=bucket,
+                    progress=progress,
                 )
                 gap_summaries.append(summary)
                 total_requests += summary.requests
@@ -547,6 +652,16 @@ async def collect_recent_summary(
                         "written_total": total_written,
                         "requests_total": total_requests,
                     },
+                )
+                await emit_progress(
+                    progress,
+                    "summary_collector:interval_progress",
+                    symbol=symbol,
+                    interval=interval,
+                    gap_from=gap.get("from"),
+                    gap_to=gap.get("to"),
+                    written_total=total_written,
+                    requests_total=total_requests,
                 )
 
             refreshed = await _fetch_existing(
@@ -577,6 +692,17 @@ async def collect_recent_summary(
                     "remaining_gaps": len(remaining),
                 },
             )
+            await emit_progress(
+                progress,
+                "summary_collector:interval_finished",
+                symbol=symbol,
+                interval=interval,
+                gaps_total=len(gaps),
+                candles_written=summaries[interval].candles_written,
+                dropped_candles=summaries[interval].dropped_candles,
+                requests=summaries[interval].requests,
+                remaining_gaps=len(remaining),
+            )
 
     summary = CollectionSummary(
         symbol=symbol.upper(),
@@ -596,6 +722,14 @@ async def collect_recent_summary(
             "candles_written": summary.candles_written,
             "dropped_candles": summary.dropped_candles,
         },
+    )
+    await emit_progress(
+        progress,
+        "summary_collector:finished",
+        symbol=summary.symbol,
+        requests=summary.requests,
+        candles_written=summary.candles_written,
+        dropped_candles=summary.dropped_candles,
     )
 
     return summary

--- a/src/services/tracing.py
+++ b/src/services/tracing.py
@@ -1,0 +1,47 @@
+"""Tracing and diagnostic helpers for the service layer.
+
+The tracing module exposes a module-level ``LOGGER`` whose verbosity can be
+controlled through the ``APP_TRACE`` environment variable. Setting the
+variable to ``"on"`` promotes the logger to DEBUG while keeping INFO as the
+default level otherwise. The logger intentionally relies on propagation so
+that Uvicorn's logging configuration remains in control of handler setup.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Mapping
+
+__all__ = ["LOGGER", "is_trace_enabled", "trace", "_TRACE_ENABLED"]
+
+_TRACE_ENABLED = os.getenv("APP_TRACE", "").lower() == "on"
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG if _TRACE_ENABLED else logging.INFO)
+# ``LOGGER.propagate`` remains untouched (True by default) to allow upstream
+# handlers configured by Uvicorn to process emitted records.
+
+
+def is_trace_enabled() -> bool:
+    """Return whether detailed trace logging is enabled."""
+
+    return _TRACE_ENABLED
+
+
+def trace(event: str, extra: Mapping[str, Any] | None = None) -> None:
+    """Emit a structured INFO log entry for the provided event.
+
+    Parameters
+    ----------
+    event:
+        The event name or message to log.
+    extra:
+        Optional dictionary merged into the log record via the ``extra``
+        parameter. The mapping defaults to an empty dictionary when omitted to
+        avoid mutating logging internals with ``None`` values.
+    """
+
+    if extra is None:
+        LOGGER.info(event)
+    else:
+        LOGGER.info(event, extra=dict(extra))

--- a/tests/test_session_collector.py
+++ b/tests/test_session_collector.py
@@ -1,0 +1,23 @@
+import pytest
+
+from src.services.session_collector import collect_last_session_detailed
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def test_collect_last_session_reports_progress():
+    events: list[str] = []
+
+    async def reporter(event: str, payload):
+        events.append(event)
+
+    result = await collect_last_session_detailed("BTCUSDT", progress=reporter)
+
+    assert result.symbol == "BTCUSDT"
+    assert events[0] == "session_collector:start"
+    assert "session_collector:finished" in events

--- a/tests/test_summary_collector.py
+++ b/tests/test_summary_collector.py
@@ -149,3 +149,41 @@ async def test_collect_recent_summary_ignores_open_tail(monkeypatch):
     assert interval_summary.gaps_total == 0
     assert interval_summary.requests == 0
     assert interval_summary.remaining_gaps == []
+
+
+async def test_collect_recent_summary_reports_progress(monkeypatch):
+    symbol = "ADAUSDT"
+    interval = "1m"
+    repo = candles_repository.get_repository()
+    interval_ms = TIMEFRAME_TO_MS[interval]
+    start_ms = 1_702_000_000_000
+    start_ms = (start_ms // interval_ms) * interval_ms
+    end_ms = start_ms + interval_ms * 2
+
+    events: list[str] = []
+
+    async def fake_request(client, *, symbol, interval, start_ms, end_ms, limit, bucket):
+        rows = []
+        cursor = start_ms
+        while cursor <= end_ms - interval_ms:
+            rows.append([cursor, 100.0, 101.0, 99.0, 100.5, 1.0])
+            cursor += interval_ms
+        return rows
+
+    async def reporter(event: str, payload):
+        events.append(event)
+
+    monkeypatch.setattr(summary_collector, "_request_klines", fake_request)
+
+    await collect_recent_summary(
+        symbol,
+        days=1,
+        end_ms=end_ms,
+        intervals=[interval],
+        start_ms=start_ms,
+        progress=reporter,
+    )
+
+    assert "summary_collector:start" in events
+    assert any(event.startswith("summary_collector:gap") for event in events)
+    assert "summary_collector:finished" in events

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+import logging
+
+import pytest
+
+MODULE_PATH = "src.services.tracing"
+
+
+def _reload_tracing(monkeypatch: pytest.MonkeyPatch, value: str | None):
+    if value is None:
+        monkeypatch.delenv("APP_TRACE", raising=False)
+    else:
+        monkeypatch.setenv("APP_TRACE", value)
+
+    if MODULE_PATH in sys.modules:
+        del sys.modules[MODULE_PATH]
+
+    return importlib.import_module(MODULE_PATH)
+
+
+def test_tracing_logger_defaults_to_info(monkeypatch: pytest.MonkeyPatch):
+    tracing = _reload_tracing(monkeypatch, None)
+
+    assert tracing.is_trace_enabled() is False
+    assert tracing.LOGGER.level == logging.INFO
+    assert tracing.LOGGER.propagate is True
+
+
+def test_tracing_logger_promoted_to_debug(monkeypatch: pytest.MonkeyPatch, caplog):
+    tracing = _reload_tracing(monkeypatch, "on")
+
+    assert tracing.is_trace_enabled() is True
+    assert tracing.LOGGER.level == logging.DEBUG
+
+    with caplog.at_level(logging.INFO, logger=tracing.LOGGER.name):
+        tracing.LOGGER.info("tracing-event", extra={"stage": "test"})
+
+    assert any(record.message == "tracing-event" for record in caplog.records)


### PR DESCRIPTION
## Summary
- add a tracing module that configures its logger level based on the APP_TRACE environment flag
- keep propagation enabled so log records bubble up to Uvicorn handlers and expose helper utilities
- add regression tests ensuring the logger respects the flag and still emits INFO records

## Testing
- pytest tests/test_tracing.py

------
https://chatgpt.com/codex/tasks/task_e_68e03f607208832484cfde4d8a4c0928