### PR TITLE
Implement shared candle batching and idempotent API responses

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -52,16 +52,6 @@
     valSeries: null,
     inspectProgressTimer: null,
     lastSnapshotId: null,
-    shared: {
-      pending: new Map(),
-      resetPending: false,
-      lastUpdateMs: null,
-      flushTimer: null,
-      inFlight: false,
-      dirty: false,
-      lastFlushMs: 0,
-      flushPromise: null,
-    },
   };
 
   const marketStore =
@@ -209,151 +199,40 @@
   }
 
   function persistSharedCandles({ bars = null, reset = false, lastUpdateMs = null, immediate = false } = {}) {
-    const shared = state.shared;
-    if (reset) {
-      shared.pending = new Map();
-      shared.resetPending = true;
-    }
-    const entries = Array.isArray(bars) ? bars : [];
-    for (const bar of entries) {
-      const sharedBar = toSharedBar(bar);
-      if (!sharedBar) continue;
-      shared.pending.set(sharedBar.time, sharedBar);
-    }
-    if (Number.isFinite(lastUpdateMs)) {
-      shared.lastUpdateMs = Number(lastUpdateMs);
-    }
-    if (shared.pending.size || shared.resetPending) {
-      scheduleSharedFlush({ immediate: immediate || reset });
-    }
-  }
-
-  function scheduleSharedFlush({ immediate = false, waitMs = null, force = false } = {}) {
-    const shared = state.shared;
-    const now = Date.now();
-    const sinceLast = now - (shared.lastFlushMs || 0);
-    let delay;
-    if (Number.isFinite(waitMs)) {
-      delay = Math.max(0, waitMs);
-    } else {
-      const baseDelay = Math.max(0, 1000 - sinceLast);
-      delay = immediate ? baseDelay : Math.max(250, baseDelay);
-    }
-    if (delay === 0 && shared.flushTimer) {
-      clearTimeout(shared.flushTimer);
-      shared.flushTimer = null;
-    }
-    if (shared.flushTimer) {
+    if (!SharedCandles || typeof SharedCandles.merge !== "function") {
       return;
     }
-    shared.flushTimer = setTimeout(() => {
-      shared.flushTimer = null;
-      flushSharedCandles({ force }).catch((error) => {
-        console.warn("SharedCandles flush failed", error);
+    const payload = Array.isArray(bars)
+      ? bars.map((bar) => toSharedBar(bar)).filter(Boolean)
+      : [];
+    try {
+      SharedCandles.merge(state.symbol, state.interval, payload, {
+        intervalMs: intervalToMs(state.interval),
+        lastUpdateMs,
+        maxBars: 2000,
+        reset,
+        immediate,
       });
-    }, delay);
-  }
-
-  function wait(ms) {
-    return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+      if (immediate && SharedCandles.flush) {
+        SharedCandles.flush(state.symbol, state.interval, { force: true }).catch((error) => {
+          console.warn("SharedCandles flush failed", error);
+        });
+      }
+    } catch (error) {
+      console.warn("SharedCandles merge failed", error);
+    }
   }
 
   async function flushSharedCandles({ force = false } = {}) {
-    const shared = state.shared;
-    if (!shared.pending.size && !shared.resetPending) {
-      return;
+    if (!SharedCandles || typeof SharedCandles.flush !== "function") {
+      return Promise.resolve();
     }
-    if (shared.inFlight) {
-      shared.dirty = true;
-      return shared.flushPromise || Promise.resolve();
+    try {
+      return await SharedCandles.flush(state.symbol, state.interval, { force });
+    } catch (error) {
+      console.warn("SharedCandles flush failed", error);
+      return Promise.resolve();
     }
-
-    const execute = async () => {
-      const now = Date.now();
-      const sinceLast = now - (shared.lastFlushMs || 0);
-      if (!force && sinceLast < 1000) {
-        scheduleSharedFlush({ waitMs: 1000 - sinceLast });
-        return;
-      }
-      if (force && sinceLast < 1000) {
-        await wait(1000 - sinceLast);
-      }
-      if (shared.flushTimer) {
-        clearTimeout(shared.flushTimer);
-        shared.flushTimer = null;
-      }
-      const pendingEntries = Array.from(shared.pending.values());
-      const reset = shared.resetPending;
-      const lastUpdateMs = Number.isFinite(shared.lastUpdateMs) ? Number(shared.lastUpdateMs) : Date.now();
-      shared.pending = new Map();
-      shared.resetPending = false;
-      shared.inFlight = true;
-      shared.dirty = false;
-
-      const payload = pendingEntries
-        .map((bar) => ({ ...bar }))
-        .sort((a, b) => Number(a.time) - Number(b.time));
-
-      if (SharedCandles && typeof SharedCandles.merge === "function") {
-        try {
-          SharedCandles.merge(state.symbol, state.interval, payload, {
-            intervalMs: intervalToMs(state.interval),
-            lastUpdateMs,
-            maxBars: 2000,
-            reset,
-            syncRemote: false,
-          });
-        } catch (error) {
-          console.warn("SharedCandles local merge failed", error);
-        }
-      }
-
-      try {
-        const response = await fetch("/shared-candles", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          cache: "no-store",
-          body: JSON.stringify({
-            symbol: state.symbol,
-            interval: state.interval,
-            candles: payload,
-            reset,
-            intervalMs: intervalToMs(state.interval),
-            lastUpdateMs,
-            maxBars: 2000,
-          }),
-        });
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-        shared.lastFlushMs = Date.now();
-        shared.lastUpdateMs = lastUpdateMs;
-      } catch (error) {
-        console.warn("SharedCandles remote sync failed", error);
-        const buffer = shared.pending;
-        if (reset) {
-          buffer.clear();
-        }
-        for (const bar of payload) {
-          buffer.set(Number(bar.time), { ...bar });
-        }
-        shared.resetPending = reset || shared.resetPending;
-        shared.dirty = true;
-      } finally {
-        shared.inFlight = false;
-        if (!shared.dirty) {
-          shared.lastFlushMs = shared.lastFlushMs || Date.now();
-        }
-        if (shared.dirty || shared.pending.size) {
-          scheduleSharedFlush();
-        }
-      }
-    };
-
-    shared.flushPromise = execute().finally(() => {
-      shared.flushPromise = null;
-    });
-    return shared.flushPromise;
   }
 
   function mergeCandles(bars, { reset = false, lastUpdateMs = null, immediate = false } = {}) {
@@ -727,6 +606,13 @@
 
   async function loadSymbol(symbol, interval) {
     notifyStatus("Загружаем историю...", "info");
+    const previousSymbol = state.symbol;
+    const previousInterval = state.interval;
+    if (SharedCandles && typeof SharedCandles.flush === "function") {
+      SharedCandles.flush(previousSymbol, previousInterval, { force: true }).catch((error) => {
+        console.warn("SharedCandles flush before switch failed", error);
+      });
+    }
     const normalizedSymbol = symbol.trim().toUpperCase();
     const normalizedInterval = interval.trim();
     state.symbol = normalizedSymbol;
@@ -735,17 +621,6 @@
     setActiveSymbolButton(normalizedSymbol);
     fetchPreset(normalizedSymbol);
     initChart();
-    if (state.shared.flushTimer) {
-      clearTimeout(state.shared.flushTimer);
-      state.shared.flushTimer = null;
-    }
-    state.shared.pending = new Map();
-    state.shared.resetPending = false;
-    state.shared.lastUpdateMs = null;
-    state.shared.inFlight = false;
-    state.shared.dirty = false;
-    state.shared.lastFlushMs = 0;
-    state.shared.flushPromise = null;
     const restored = await restoreFromSharedStore(normalizedSymbol, normalizedInterval);
     if (restored) {
       applyCandles();

--- a/public/shared-candles.js
+++ b/public/shared-candles.js
@@ -2,12 +2,22 @@
   "use strict";
 
   const STORAGE_KEY = "shared-candles-store";
-  const DEFAULT_MAX_BARS = 2000;
+  const LEADER_PREFIX = "shared-candles-leader:";
   const REMOTE_ENDPOINT = "/shared-candles";
+  const DEFAULT_MAX_BARS = 2000;
+  const DEBOUNCE_MIN_MS = 1000;
+  const DEBOUNCE_MAX_MS = 2000;
+  const LEADER_TTL_MS = 4000;
+  const LEADER_REFRESH_THRESHOLD_MS = 800;
+  const instanceId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
   const memoryCache = new Map();
-  const remoteQueue = new Map();
+  const states = new Map();
   let storageAvailable = null;
-  let remoteTimer = null;
+
+  function now() {
+    return Date.now();
+  }
 
   function canUseLocalStorage() {
     if (storageAvailable !== null) {
@@ -58,6 +68,9 @@
   function makeKey(symbol, interval) {
     const safeSymbol = (symbol || "").trim().toUpperCase();
     const safeInterval = (interval || "").trim().toLowerCase();
+    if (!safeSymbol || !safeInterval) {
+      throw new Error("symbol and interval are required");
+    }
     return `${safeSymbol}|${safeInterval}`;
   }
 
@@ -72,6 +85,7 @@
     if (!Number.isFinite(tsMs)) {
       tsMs = Number.isFinite(timeSeconds) ? timeSeconds * 1000 : NaN;
     }
+    const volume = Number(bar.volume ?? bar.v);
     const lastUpdate = Number(bar.last_update_ms ?? bar.lastUpdateMs ?? bar.last_update ?? bar.lastupdate);
     if (
       !Number.isFinite(timeSeconds) ||
@@ -82,15 +96,21 @@
     ) {
       return null;
     }
-    return {
+    const payload = {
       time: Math.floor(timeSeconds),
       open,
       high,
       low,
       close,
       ts_ms_utc: Math.floor(tsMs),
-      ...(Number.isFinite(lastUpdate) ? { last_update_ms: Math.floor(lastUpdate) } : {}),
     };
+    if (Number.isFinite(volume)) {
+      payload.volume = Number(volume);
+    }
+    if (Number.isFinite(lastUpdate)) {
+      payload.last_update_ms = Math.floor(lastUpdate);
+    }
+    return payload;
   }
 
   function mergeBars(existing, incoming, maxBars) {
@@ -100,22 +120,20 @@
       if (!bar) continue;
       const time = Number(bar.time);
       if (!Number.isFinite(time)) continue;
-      index.set(time, merged.length);
-      merged.push(bar);
+      const normalised = normaliseBar(bar);
+      if (!normalised) continue;
+      index.set(normalised.time, normalised);
     }
     for (const bar of incoming) {
       if (!bar) continue;
-      const time = Number(bar.time);
-      if (!Number.isFinite(time)) continue;
-      if (index.has(time)) {
-        merged[index.get(time)] = bar;
-      } else {
-        index.set(time, merged.length);
-        merged.push(bar);
-      }
+      const normalised = normaliseBar(bar);
+      if (!normalised) continue;
+      index.set(normalised.time, normalised);
     }
-    merged.sort((a, b) => a.time - b.time);
-    const limit = Math.max(1, Number(maxBars) || DEFAULT_MAX_BARS);
+    for (const entry of Array.from(index.entries()).sort((a, b) => a[0] - b[0])) {
+      merged.push(entry[1]);
+    }
+    const limit = Math.max(1, Number.isFinite(maxBars) ? Number(maxBars) : DEFAULT_MAX_BARS);
     return merged.length > limit ? merged.slice(merged.length - limit) : merged;
   }
 
@@ -124,128 +142,295 @@
       return memoryCache.get(key);
     }
     const store = loadStore();
-    const entry = store[key] || null;
-    if (entry) {
-      memoryCache.set(key, entry);
+    const entry = store[key];
+    if (!entry || typeof entry !== "object") {
+      return null;
     }
-    return entry;
+    const cloned = {
+      candles: Array.isArray(entry.candles) ? entry.candles.slice() : [],
+      intervalMs: Number.isFinite(entry.intervalMs) ? Number(entry.intervalMs) : null,
+      lastUpdateMs: Number.isFinite(entry.lastUpdateMs) ? Number(entry.lastUpdateMs) : null,
+      updatedAt: Number.isFinite(entry.updatedAt) ? Number(entry.updatedAt) : null,
+      maxBars: Number.isFinite(entry.maxBars) ? Number(entry.maxBars) : null,
+    };
+    memoryCache.set(key, cloned);
+    return cloned;
   }
 
   function writeEntry(key, entry) {
     if (entry) {
-      memoryCache.set(key, entry);
+      const payload = {
+        candles: Array.isArray(entry.candles) ? entry.candles.map((bar) => ({ ...bar })) : [],
+        intervalMs: Number.isFinite(entry.intervalMs) ? Number(entry.intervalMs) : null,
+        lastUpdateMs: Number.isFinite(entry.lastUpdateMs) ? Number(entry.lastUpdateMs) : null,
+        updatedAt: Number.isFinite(entry.updatedAt) ? Number(entry.updatedAt) : now(),
+        maxBars: Number.isFinite(entry.maxBars) ? Number(entry.maxBars) : null,
+      };
+      memoryCache.set(key, payload);
+      if (canUseLocalStorage()) {
+        const store = loadStore();
+        store[key] = payload;
+        saveStore(store);
+      }
     } else {
       memoryCache.delete(key);
+      if (canUseLocalStorage()) {
+        const store = loadStore();
+        delete store[key];
+        saveStore(store);
+      }
     }
+  }
+
+  function removeLeader(key) {
+    if (!canUseLocalStorage()) return;
+    try {
+      global.localStorage.removeItem(`${LEADER_PREFIX}${key}`);
+    } catch (error) {
+      console.warn("SharedCandles: failed to remove leader lock", error);
+    }
+  }
+
+  function ensureState(key, symbol, interval) {
+    if (states.has(key)) {
+      return states.get(key);
+    }
+    const entry = readEntry(key);
+    const state = {
+      key,
+      symbol: (symbol || "").trim().toUpperCase(),
+      interval: (interval || "").trim().toLowerCase(),
+      pending: new Map(),
+      resetPending: false,
+      pendingLastUpdateMs: null,
+      flushTimer: null,
+      flushDueTime: null,
+      inFlight: false,
+      dirty: false,
+      flushPromise: null,
+      lastFlushMs: 0,
+      lastUpdateMs: entry && Number.isFinite(entry.lastUpdateMs) ? Number(entry.lastUpdateMs) : null,
+      intervalMs: entry && Number.isFinite(entry.intervalMs) ? Number(entry.intervalMs) : null,
+      maxBars: entry && Number.isFinite(entry.maxBars) ? Number(entry.maxBars) : DEFAULT_MAX_BARS,
+      debounceMs:
+        Math.floor(Math.random() * (DEBOUNCE_MAX_MS - DEBOUNCE_MIN_MS + 1)) + DEBOUNCE_MIN_MS,
+      leaderExpiresAt: 0,
+    };
+    states.set(key, state);
+    return state;
+  }
+
+  function trimPending(state) {
+    const limit = Math.max(1, Number.isFinite(state.maxBars) ? Number(state.maxBars) : DEFAULT_MAX_BARS);
+    const entries = Array.from(state.pending.entries()).sort((a, b) => Number(a[0]) - Number(b[0]));
+    const trimmed = entries.length > limit ? entries.slice(entries.length - limit) : entries;
+    state.pending = new Map(trimmed.map(([time, bar]) => [Number(time), { ...bar }]));
+  }
+
+  function ensureLeader(state) {
     if (!canUseLocalStorage()) {
+      return true;
+    }
+    const lockKey = `${LEADER_PREFIX}${state.key}`;
+    const nowMs = now();
+    let ownerId = null;
+    let expiresAt = 0;
+    try {
+      const raw = global.localStorage.getItem(lockKey);
+      if (raw) {
+        const parts = String(raw).split("|");
+        if (parts.length === 2) {
+          ownerId = parts[0];
+          expiresAt = Number(parts[1]);
+        }
+      }
+    } catch (error) {
+      console.warn("SharedCandles: failed to read leader lock", error);
+      return true;
+    }
+
+    const refresh = () => {
+      const nextExpiry = nowMs + LEADER_TTL_MS;
+      try {
+        global.localStorage.setItem(lockKey, `${instanceId}|${nextExpiry}`);
+      } catch (error) {
+        console.warn("SharedCandles: failed to extend leader lock", error);
+      }
+      state.leaderExpiresAt = nextExpiry;
+    };
+
+    if (!ownerId || !Number.isFinite(expiresAt) || expiresAt <= nowMs) {
+      refresh();
+      return true;
+    }
+    if (ownerId === instanceId) {
+      if (expiresAt - nowMs <= LEADER_REFRESH_THRESHOLD_MS) {
+        refresh();
+      } else {
+        state.leaderExpiresAt = expiresAt;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  function scheduleFlush(state, { immediate = false, delayMs = null } = {}) {
+    let delay;
+    if (immediate) {
+      delay = 0;
+    } else if (Number.isFinite(delayMs)) {
+      delay = Math.max(0, Number(delayMs));
+    } else {
+      delay = state.debounceMs;
+    }
+    const dueTime = now() + delay;
+    if (state.flushTimer && state.flushDueTime !== null && state.flushDueTime <= dueTime) {
       return;
     }
-    const store = loadStore();
-    if (entry) {
-      store[key] = entry;
-    } else {
-      delete store[key];
+    if (state.flushTimer) {
+      clearTimeout(state.flushTimer);
     }
-    saveStore(store);
+    state.flushDueTime = dueTime;
+    state.flushTimer = setTimeout(() => {
+      state.flushTimer = null;
+      state.flushDueTime = null;
+      triggerFlush(state).catch((error) => {
+        console.warn("SharedCandles: remote flush failed", error);
+      });
+    }, delay);
   }
 
-  function scheduleRemoteFlush() {
-    if (remoteTimer) return;
-    remoteTimer = setTimeout(() => {
-      remoteTimer = null;
-      flushRemoteQueue().catch((error) => {
-        console.warn("SharedCandles: remote sync failed", error);
-      });
-    }, 250);
-  }
-
-  function queueRemoteSync(symbol, interval, candles, options = {}) {
-    if (!Array.isArray(candles) || !candles.length) return;
-    if (!symbol || !interval) return;
-    const key = makeKey(symbol, interval);
-    const normalizedSymbol = symbol.trim().toUpperCase();
-    const normalizedInterval = interval.trim().toLowerCase();
-    const intervalMs = Number.isFinite(Number(options.intervalMs))
-      ? Number(options.intervalMs)
-      : null;
-    const lastUpdateMs = Number.isFinite(Number(options.lastUpdateMs))
-      ? Number(options.lastUpdateMs)
-      : null;
-    const maxBars = Number.isFinite(Number(options.maxBars))
-      ? Number(options.maxBars)
-      : null;
-    const reset = Boolean(options.reset);
-
-    const existing = remoteQueue.get(key);
-    if (reset) {
-      remoteQueue.set(key, {
-        symbol: normalizedSymbol,
-        interval: normalizedInterval,
-        candles: candles.slice(),
-        reset: true,
-        intervalMs,
-        lastUpdateMs,
-        maxBars,
-      });
-    } else if (existing) {
-      const mergedCandles = mergeBars(
-        existing.candles,
-        candles,
-        maxBars || existing.maxBars || DEFAULT_MAX_BARS,
-      );
-      remoteQueue.set(key, {
-        symbol: existing.symbol,
-        interval: existing.interval,
-        candles: mergedCandles,
-        reset: existing.reset,
-        intervalMs: intervalMs ?? existing.intervalMs ?? null,
-        lastUpdateMs: lastUpdateMs ?? existing.lastUpdateMs ?? null,
-        maxBars: maxBars ?? existing.maxBars ?? null,
-      });
-    } else {
-      remoteQueue.set(key, {
-        symbol: normalizedSymbol,
-        interval: normalizedInterval,
-        candles: candles.slice(),
-        reset: false,
-        intervalMs,
-        lastUpdateMs,
-        maxBars,
-      });
+  function restoreSnapshot(state, snapshot) {
+    const buffer = new Map(state.pending);
+    if (snapshot.reset) {
+      buffer.clear();
+      state.resetPending = true;
     }
-
-    scheduleRemoteFlush();
+    for (const [time, bar] of snapshot.entries) {
+      buffer.set(Number(time), { ...bar });
+    }
+    state.pending = buffer;
+    trimPending(state);
+    if (Number.isFinite(snapshot.lastUpdateMs)) {
+      const candidate = Number(snapshot.lastUpdateMs);
+      const current = Number.isFinite(state.pendingLastUpdateMs)
+        ? Number(state.pendingLastUpdateMs)
+        : -Infinity;
+      state.pendingLastUpdateMs = Math.max(current, candidate);
+    }
+    state.dirty = true;
   }
 
-  async function flushRemoteQueue() {
-    if (!remoteQueue.size) return;
-    const entries = Array.from(remoteQueue.values());
-    remoteQueue.clear();
-    for (const entry of entries) {
-      const body = {
-        symbol: entry.symbol,
-        interval: entry.interval,
-        candles: entry.candles,
-        reset: Boolean(entry.reset),
-        intervalMs: entry.intervalMs,
-        lastUpdateMs: entry.lastUpdateMs,
-      };
-      if (Number.isFinite(Number(entry.maxBars))) {
-        body.maxBars = Number(entry.maxBars);
+  function triggerFlush(state, { force = false } = {}) {
+    if (state.inFlight) {
+      state.dirty = true;
+      return state.flushPromise || Promise.resolve();
+    }
+    if (!state.pending.size && !state.resetPending) {
+      if (state.flushTimer) {
+        clearTimeout(state.flushTimer);
+        state.flushTimer = null;
+        state.flushDueTime = null;
       }
+      return force && state.flushPromise ? state.flushPromise : Promise.resolve();
+    }
+    if (!ensureLeader(state)) {
+      scheduleFlush(state);
+      return Promise.resolve();
+    }
+
+    const pendingEntries = Array.from(state.pending.entries());
+    const resetFlag = state.resetPending;
+    const payloadBars = pendingEntries.map(([, bar]) => ({ ...bar }));
+    const sortedBars = payloadBars.sort((a, b) => Number(a.time) - Number(b.time));
+    const trimmedBars = sortedBars.length > state.maxBars
+      ? sortedBars.slice(sortedBars.length - state.maxBars)
+      : sortedBars;
+    const fallbackUpdate = Number.isFinite(state.lastUpdateMs) ? Number(state.lastUpdateMs) : now();
+    const pendingUpdate = Number.isFinite(state.pendingLastUpdateMs)
+      ? Number(state.pendingLastUpdateMs)
+      : fallbackUpdate;
+    const body = {
+      symbol: state.symbol,
+      interval: state.interval,
+      candles: trimmedBars,
+      reset: Boolean(resetFlag),
+      lastUpdateMs: pendingUpdate,
+    };
+    if (Number.isFinite(state.intervalMs)) {
+      body.intervalMs = Number(state.intervalMs);
+    }
+    if (Number.isFinite(state.maxBars)) {
+      body.maxBars = Number(state.maxBars);
+    }
+
+    const snapshot = {
+      entries: pendingEntries,
+      reset: resetFlag,
+      lastUpdateMs: pendingUpdate,
+    };
+
+    state.pending = new Map();
+    state.resetPending = false;
+    state.pendingLastUpdateMs = null;
+    state.inFlight = true;
+    state.dirty = false;
+
+    const execute = async () => {
+      let shouldRestore = false;
+      let retryDelay = null;
+      let rateLimited = false;
       try {
         const response = await fetch(REMOTE_ENDPOINT, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
+          cache: "no-store",
           body: JSON.stringify(body),
         });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
+        let payload = null;
+        try {
+          payload = await response.json();
+        } catch (error) {
+          payload = null;
+        }
+        const status = payload && typeof payload.status === "string" ? payload.status : "ok";
+        if (status === "rate_limited") {
+          shouldRestore = true;
+          rateLimited = true;
+          retryDelay = Number.isFinite(payload?.retryAfterMs)
+            ? Number(payload.retryAfterMs)
+            : state.debounceMs;
+          return;
+        }
+        const responseUpdate = Number.isFinite(payload?.lastUpdateMs)
+          ? Number(payload.lastUpdateMs)
+          : pendingUpdate;
+        if (Number.isFinite(responseUpdate)) {
+          state.lastUpdateMs = responseUpdate;
+        }
+        state.lastFlushMs = now();
       } catch (error) {
-        console.warn("SharedCandles: remote sync error", error);
+        shouldRestore = true;
+        throw error;
+      } finally {
+        if (shouldRestore) {
+          restoreSnapshot(state, snapshot);
+        }
+        state.inFlight = false;
+        state.flushPromise = null;
+        if (rateLimited) {
+          scheduleFlush(state, { delayMs: retryDelay });
+        } else if (state.dirty || state.pending.size || state.resetPending) {
+          scheduleFlush(state);
+        }
       }
-    }
+    };
+
+    state.flushPromise = execute();
+    return state.flushPromise;
   }
 
   async function fetchRemote(symbol, interval) {
@@ -279,8 +464,13 @@
   }
 
   function get(symbol, interval) {
-    const key = makeKey(symbol, interval);
-    const entry = readEntry(key);
+    let entry;
+    try {
+      const key = makeKey(symbol, interval);
+      entry = readEntry(key);
+    } catch (error) {
+      return null;
+    }
     if (!entry) return null;
     const bars = Array.isArray(entry.candles)
       ? entry.candles.map((bar) => normaliseBar(bar)).filter(Boolean)
@@ -288,59 +478,144 @@
     if (!bars.length) return null;
     return {
       candles: bars,
-      intervalMs: Number(entry.intervalMs) || null,
-      lastUpdateMs: Number(entry.lastUpdateMs) || null,
-      updatedAt: Number(entry.updatedAt) || null,
+      intervalMs: Number.isFinite(entry.intervalMs) ? Number(entry.intervalMs) : null,
+      lastUpdateMs: Number.isFinite(entry.lastUpdateMs) ? Number(entry.lastUpdateMs) : null,
+      updatedAt: Number.isFinite(entry.updatedAt) ? Number(entry.updatedAt) : null,
     };
   }
 
   function merge(symbol, interval, candles, options = {}) {
-    const key = makeKey(symbol, interval);
-    const normalizedIncoming = Array.isArray(candles)
+    let key;
+    try {
+      key = makeKey(symbol, interval);
+    } catch (error) {
+      console.warn("SharedCandles: merge skipped due to invalid key", error);
+      return [];
+    }
+    const syncRemote = options.syncRemote !== false;
+    const reset = Boolean(options.reset);
+    const incomingLastUpdate = Number.isFinite(Number(options.lastUpdateMs))
+      ? Number(options.lastUpdateMs)
+      : null;
+    const intervalMs = Number.isFinite(Number(options.intervalMs))
+      ? Number(options.intervalMs)
+      : null;
+    const maxBars = Number.isFinite(Number(options.maxBars)) ? Number(options.maxBars) : null;
+
+    const state = ensureState(key, symbol, interval);
+    const entry = readEntry(key);
+    const existingBars = entry && Array.isArray(entry.candles) ? entry.candles : [];
+    const existingLastUpdate = Number.isFinite(entry?.lastUpdateMs) ? Number(entry.lastUpdateMs) : null;
+    if (state.lastUpdateMs === null && existingLastUpdate !== null) {
+      state.lastUpdateMs = existingLastUpdate;
+    }
+
+    const normalisedIncoming = Array.isArray(candles)
       ? candles.map((bar) => normaliseBar(bar)).filter(Boolean)
       : [];
-    if (!normalizedIncoming.length) {
-      return get(symbol, interval)?.candles || [];
+
+    if (!reset && incomingLastUpdate !== null && state.lastUpdateMs !== null) {
+      if (incomingLastUpdate <= state.lastUpdateMs) {
+        return mergeBars(existingBars, [], maxBars ?? state.maxBars);
+      }
     }
-    const reset = Boolean(options.reset);
-    const syncRemote = options.syncRemote !== false;
-    const existingEntry = reset ? null : readEntry(key);
-    const existingBars = existingEntry && Array.isArray(existingEntry.candles)
-      ? existingEntry.candles.map((bar) => normaliseBar(bar)).filter(Boolean)
-      : [];
-    const mergedBars = mergeBars(existingBars, normalizedIncoming, options.maxBars);
-    const nextEntry = {
+    if (!reset && !normalisedIncoming.length) {
+      return mergeBars(existingBars, [], maxBars ?? state.maxBars);
+    }
+
+    const limit = maxBars ?? state.maxBars ?? DEFAULT_MAX_BARS;
+    const mergedBars = mergeBars(reset ? [] : existingBars, normalisedIncoming, limit);
+    const updatedAt = now();
+    const nextLastUpdate = incomingLastUpdate ?? (reset ? null : state.lastUpdateMs);
+    const nextInterval = intervalMs ?? state.intervalMs ?? null;
+
+    writeEntry(key, {
       candles: mergedBars,
-      intervalMs: Number.isFinite(Number(options.intervalMs))
-        ? Number(options.intervalMs)
-        : existingEntry?.intervalMs ?? null,
-      lastUpdateMs: Number.isFinite(Number(options.lastUpdateMs))
-        ? Number(options.lastUpdateMs)
-        : existingEntry?.lastUpdateMs ?? null,
-      updatedAt: Date.now(),
-    };
-    writeEntry(key, nextEntry);
-    if (syncRemote) {
-      queueRemoteSync(symbol, interval, normalizedIncoming, {
-        reset,
-        intervalMs: nextEntry.intervalMs,
-        lastUpdateMs: nextEntry.lastUpdateMs,
-        maxBars: options.maxBars,
-      });
+      intervalMs: nextInterval,
+      lastUpdateMs: nextLastUpdate,
+      updatedAt,
+      maxBars: limit,
+    });
+
+    state.maxBars = limit;
+    state.intervalMs = nextInterval;
+    state.lastUpdateMs = Number.isFinite(nextLastUpdate) ? Number(nextLastUpdate) : state.lastUpdateMs;
+
+    if (syncRemote && (normalisedIncoming.length || reset)) {
+      if (reset) {
+        state.pending.clear();
+        state.resetPending = true;
+      }
+      for (const bar of normalisedIncoming) {
+        state.pending.set(Number(bar.time), { ...bar });
+      }
+      trimPending(state);
+      if (incomingLastUpdate !== null) {
+        state.pendingLastUpdateMs = Number(incomingLastUpdate);
+      } else if (state.pendingLastUpdateMs === null && state.lastUpdateMs !== null) {
+        state.pendingLastUpdateMs = Number(state.lastUpdateMs);
+      }
+      if (state.inFlight) {
+        state.dirty = true;
+      }
+      const immediate = Boolean(options.immediate || options.immediateFlush || reset);
+      if (immediate) {
+        if (state.flushTimer) {
+          clearTimeout(state.flushTimer);
+          state.flushTimer = null;
+          state.flushDueTime = null;
+        }
+        triggerFlush(state, { force: true });
+      } else {
+        const delayMs = Number.isFinite(options.flushDelayMs) ? Number(options.flushDelayMs) : null;
+        scheduleFlush(state, { delayMs });
+      }
     }
+
     return mergedBars;
   }
 
   function clear(symbol, interval) {
-    if (symbol || interval) {
-      const key = makeKey(symbol, interval);
-      writeEntry(key, null);
+    if (!symbol && !interval) {
+      memoryCache.clear();
+      if (canUseLocalStorage()) {
+        saveStore({});
+      }
+      for (const key of states.keys()) {
+        removeLeader(key);
+      }
+      states.clear();
       return;
     }
-    memoryCache.clear();
-    if (canUseLocalStorage()) {
-      saveStore({});
+    let key;
+    try {
+      key = makeKey(symbol, interval);
+    } catch (error) {
+      return;
     }
+    writeEntry(key, null);
+    removeLeader(key);
+    states.delete(key);
+  }
+
+  function flush(symbol, interval, options = {}) {
+    let key;
+    try {
+      key = makeKey(symbol, interval);
+    } catch (error) {
+      return Promise.resolve();
+    }
+    const state = states.get(key);
+    if (!state) {
+      return Promise.resolve();
+    }
+    const force = Boolean(options.force || options.immediate);
+    if (force && state.flushTimer) {
+      clearTimeout(state.flushTimer);
+      state.flushTimer = null;
+      state.flushDueTime = null;
+    }
+    return triggerFlush(state, { force });
   }
 
   global.SharedCandles = {
@@ -348,5 +623,6 @@
     merge,
     clear,
     fetchRemote,
+    flush,
   };
 })(typeof window !== "undefined" ? window : globalThis);

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1297,15 +1297,7 @@ async def update_shared_candles(payload: Dict[str, Any] = Body(...)) -> JSONResp
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    response_payload = {
-        "symbol": symbol.strip().upper(),
-        "interval": interval.strip().lower(),
-        "candles": result.get("candles", []),
-        "intervalMs": result.get("intervalMs"),
-        "lastUpdateMs": result.get("lastUpdateMs"),
-        "updatedAt": result.get("updatedAt"),
-    }
-    return JSONResponse(response_payload)
+    return JSONResponse(result)
 
 
 @app.get("/inspection", response_class=HTMLResponse)

--- a/src/services/shared_candles_store.py
+++ b/src/services/shared_candles_store.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import json
+import os
+from datetime import datetime, timezone
 from math import isfinite
 from pathlib import Path
 from threading import Lock
+from time import monotonic
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Sequence
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -17,6 +19,12 @@ DEFAULT_MAX_BARS = 2000
 
 _STORE_CACHE: Dict[str, Any] | None = None
 _STORE_LOCK = Lock()
+_WRITE_TRACKER_LOCK = Lock()
+_WRITE_RATE_LIMIT_SECONDS = max(
+    0.0,
+    float(os.environ.get("SHARED_CANDLES_RATE_LIMIT_SECONDS", "0.0")),
+)
+_WRITE_TRACKER: Dict[str, float] = {}
 
 
 def _ensure_store_dir() -> None:
@@ -199,63 +207,159 @@ def merge_shared_candles(
     reset: bool = False,
     max_bars: int | None = None,
 ) -> Dict[str, Any]:
-    """Merge incoming candles into the persistent store and return the updated state."""
+    """Merge incoming candles into the persistent store and return a compact status."""
 
     key = _make_key(symbol, interval)
-
-    incoming = list(candles or [])
-    if not incoming and not reset:
-        current = get_shared_candles(symbol, interval)
-        if current is None:
-            return {
-                "candles": [],
-                "intervalMs": None,
-                "lastUpdateMs": None,
-                "updatedAt": None,
-            }
-        return current
-
     store = _load_store()
-    existing_entry = store.get(key) if not reset else None
-    existing_candles: Sequence[Mapping[str, Any]]
+    existing_entry = store.get(key)
+
     if isinstance(existing_entry, dict):
-        existing_candles = existing_entry.get("candles", [])  # type: ignore[assignment]
+        existing_candles_raw = existing_entry.get("candles", [])
     else:
-        existing_candles = []
+        existing_candles_raw = []
 
-    merged = _merge_bars(existing_candles, incoming, max_bars=max_bars)
+    existing_candles = [
+        result
+        for bar in existing_candles_raw
+        if isinstance(bar, Mapping)
+        for result in (_normalise_bar(bar),)
+        if result is not None
+    ]
 
-    interval_ms_value = None
-    if isinstance(interval_ms, (int, float)) and isfinite(interval_ms):
-        interval_ms_value = int(interval_ms)
-    elif isinstance(existing_entry, dict):
-        previous = existing_entry.get("interval_ms")
-        if isinstance(previous, (int, float)) and isfinite(previous):
-            interval_ms_value = int(previous)
+    incoming_candles = [
+        result
+        for bar in (candles or [])
+        if isinstance(bar, Mapping)
+        for result in (_normalise_bar(bar),)
+        if result is not None
+    ]
 
-    last_update_value = None
-    if isinstance(last_update_ms, (int, float)) and isfinite(last_update_ms):
-        last_update_value = int(last_update_ms)
-    elif isinstance(existing_entry, dict):
-        previous = existing_entry.get("last_update_ms")
-        if isinstance(previous, (int, float)) and isfinite(previous):
-            last_update_value = int(previous)
+    incoming_last_update = (
+        int(last_update_ms)
+        if isinstance(last_update_ms, (int, float)) and isfinite(last_update_ms)
+        else None
+    )
+    existing_last_update = (
+        int(existing_entry.get("last_update_ms"))
+        if isinstance(existing_entry, dict)
+        and isinstance(existing_entry.get("last_update_ms"), (int, float))
+        and isfinite(existing_entry.get("last_update_ms"))
+        else None
+    )
+    existing_interval_ms = (
+        int(existing_entry.get("interval_ms"))
+        if isinstance(existing_entry, dict)
+        and isinstance(existing_entry.get("interval_ms"), (int, float))
+        and isfinite(existing_entry.get("interval_ms"))
+        else None
+    )
+    existing_updated_at = (
+        int(existing_entry.get("updated_at"))
+        if isinstance(existing_entry, dict)
+        and isinstance(existing_entry.get("updated_at"), (int, float))
+        and isfinite(existing_entry.get("updated_at"))
+        else None
+    )
+
+    if (
+        incoming_last_update is not None
+        and existing_last_update is not None
+        and incoming_last_update <= existing_last_update
+    ):
+        return {
+            "status": "noop",
+            "symbol": symbol.strip().upper(),
+            "interval": interval.strip().lower(),
+            "written": False,
+            "lastUpdateMs": existing_last_update,
+            "updatedAt": existing_updated_at,
+        }
+
+    effective_max_bars = (
+        max(1, int(max_bars))
+        if isinstance(max_bars, (int, float)) and isfinite(max_bars)
+        else None
+    )
+    if effective_max_bars is None and isinstance(existing_entry, dict):
+        stored_limit = existing_entry.get("max_bars")
+        if isinstance(stored_limit, (int, float)) and isfinite(stored_limit):
+            effective_max_bars = max(1, int(stored_limit))
+
+    merged_candles = _merge_bars(
+        [] if reset else existing_candles,
+        incoming_candles,
+        max_bars=effective_max_bars,
+    )
+
+    candles_changed = merged_candles != existing_candles
+
+    next_interval_ms = (
+        int(interval_ms)
+        if isinstance(interval_ms, (int, float)) and isfinite(interval_ms)
+        else existing_interval_ms
+    )
+
+    next_last_update = existing_last_update
+    if incoming_last_update is not None:
+        next_last_update = incoming_last_update
+    elif reset:
+        next_last_update = None
+
+    requires_write = reset or candles_changed or next_interval_ms != existing_interval_ms
+    if incoming_last_update is not None and incoming_last_update != existing_last_update:
+        requires_write = True
+
+    if not requires_write:
+        return {
+            "status": "noop",
+            "symbol": symbol.strip().upper(),
+            "interval": interval.strip().lower(),
+            "written": False,
+            "lastUpdateMs": existing_last_update,
+            "updatedAt": existing_updated_at,
+        }
+
+    now_monotonic = monotonic()
+    if not reset:
+        with _WRITE_TRACKER_LOCK:
+            last_write = _WRITE_TRACKER.get(key)
+            if last_write is not None and now_monotonic - last_write < _WRITE_RATE_LIMIT_SECONDS:
+                retry_after_ms = int(
+                    max(0, (_WRITE_RATE_LIMIT_SECONDS - (now_monotonic - last_write)) * 1000)
+                )
+                return {
+                    "status": "rate_limited",
+                    "symbol": symbol.strip().upper(),
+                    "interval": interval.strip().lower(),
+                    "written": False,
+                    "retryAfterMs": retry_after_ms,
+                    "lastUpdateMs": existing_last_update,
+                    "updatedAt": existing_updated_at,
+                }
 
     updated_at_value = _now_ms()
 
-    next_entry = {
-        "candles": merged,
-        "interval_ms": interval_ms_value,
-        "last_update_ms": last_update_value,
+    next_entry: Dict[str, Any] = {
+        "candles": merged_candles,
+        "interval_ms": next_interval_ms,
+        "last_update_ms": next_last_update,
         "updated_at": updated_at_value,
     }
+    if effective_max_bars is not None:
+        next_entry["max_bars"] = effective_max_bars
+
     store[key] = next_entry
     _persist_store(store)
 
+    with _WRITE_TRACKER_LOCK:
+        _WRITE_TRACKER[key] = now_monotonic
+
     return {
-        "candles": merged,
-        "intervalMs": interval_ms_value,
-        "lastUpdateMs": last_update_value,
+        "status": "ok",
+        "symbol": symbol.strip().upper(),
+        "interval": interval.strip().lower(),
+        "written": True,
+        "lastUpdateMs": next_last_update,
         "updatedAt": updated_at_value,
     }
 
@@ -266,6 +370,8 @@ def clear_shared_candles(symbol: str | None = None, interval: str | None = None)
     if not symbol and not interval:
         store: Dict[str, Any] = {}
         _persist_store(store)
+        with _WRITE_TRACKER_LOCK:
+            _WRITE_TRACKER.clear()
         return
 
     try:
@@ -276,6 +382,8 @@ def clear_shared_candles(symbol: str | None = None, interval: str | None = None)
     if key in store:
         del store[key]
         _persist_store(store)
+    with _WRITE_TRACKER_LOCK:
+        _WRITE_TRACKER.pop(key, None)
 
 
 def reset_store() -> None:
@@ -288,4 +396,6 @@ def reset_store() -> None:
             STORE_FILE.unlink()
         except FileNotFoundError:
             pass
+    with _WRITE_TRACKER_LOCK:
+        _WRITE_TRACKER.clear()
 

--- a/src/services/summary_collector.py
+++ b/src/services/summary_collector.py
@@ -438,15 +438,19 @@ async def _fill_gap(
                 limit=page_limit,
                 request_index=requests + 1,
             )
+        request_kwargs = {
+            "symbol": symbol,
+            "interval": interval,
+            "start_ms": cursor,
+            "end_ms": page_end + interval_ms,
+            "limit": page_limit,
+            "bucket": bucket,
+        }
+        if trace is not None:
+            request_kwargs["trace"] = trace
         raw_rows = await _request_klines(
             client,
-            symbol=symbol,
-            interval=interval,
-            start_ms=cursor,
-            end_ms=page_end + interval_ms,
-            limit=page_limit,
-            bucket=bucket,
-            trace=trace,
+            **request_kwargs,
         )
         requests += 1
         if trace is not None:

--- a/tests/test_shared_candles_api.py
+++ b/tests/test_shared_candles_api.py
@@ -1,5 +1,8 @@
-from pathlib import Path
+from __future__ import annotations
+
 import sys
+from pathlib import Path
+from typing import Dict
 
 import pytest
 from fastapi.testclient import TestClient
@@ -9,6 +12,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from src.api.app import app
+from src.services import shared_candles_store
 
 
 @pytest.fixture()
@@ -16,10 +20,23 @@ def client() -> TestClient:
     return TestClient(app)
 
 
-def test_shared_candles_returns_empty_payload(client: TestClient) -> None:
-    response = client.get("/shared-candles", params={"symbol": "BTCUSDT", "interval": "1m"})
+def _merge(client: TestClient, payload: Dict[str, object]) -> Dict[str, object]:
+    response = client.post("/shared-candles", json=payload)
     assert response.status_code == 200
-    payload = response.json()
+    return response.json()
+
+
+def _fetch(client: TestClient, symbol: str, interval: str) -> Dict[str, object]:
+    response = client.get(
+        "/shared-candles",
+        params={"symbol": symbol, "interval": interval},
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+def test_shared_candles_returns_empty_payload(client: TestClient) -> None:
+    payload = _fetch(client, "BTCUSDT", "1m")
     assert payload["symbol"] == "BTCUSDT"
     assert payload["interval"] == "1m"
     assert payload["candles"] == []
@@ -40,23 +57,19 @@ def test_shared_candles_merge_and_fetch_roundtrip(client: TestClient) -> None:
         "reset": True,
     }
 
-    first_response = client.post("/shared-candles", json=merge_payload)
-    assert first_response.status_code == 200
-    created = first_response.json()
-    assert [bar["time"] for bar in created["candles"]] == [1_700_000_000, 1_700_000_060]
-    assert created["intervalMs"] == 60_000
+    created = _merge(client, merge_payload)
+    assert created["status"] == "ok"
+    assert created["written"] is True
     assert created["lastUpdateMs"] == 1_700_000_120_000
 
-    fetch_response = client.get("/shared-candles", params={"symbol": "btcusdt", "interval": "1M"})
-    assert fetch_response.status_code == 200
-    fetched = fetch_response.json()
+    fetched = _fetch(client, "btcusdt", "1M")
     assert fetched["symbol"] == "BTCUSDT"
     assert fetched["interval"] == "1m"
     assert [bar["time"] for bar in fetched["candles"]] == [1_700_000_000, 1_700_000_060]
 
-    incremental_response = client.post(
-        "/shared-candles",
-        json={
+    incremental = _merge(
+        client,
+        {
             "symbol": "BTCUSDT",
             "interval": "1m",
             "candles": [
@@ -66,14 +79,72 @@ def test_shared_candles_merge_and_fetch_roundtrip(client: TestClient) -> None:
             "lastUpdateMs": 1_700_000_180_000,
         },
     )
-    assert incremental_response.status_code == 200
-    merged = incremental_response.json()
-    assert [bar["time"] for bar in merged["candles"]] == [
+    assert incremental["status"] == "ok"
+    assert incremental["written"] is True
+    assert incremental["lastUpdateMs"] == 1_700_000_180_000
+
+    fetched_after = _fetch(client, "BTCUSDT", "1m")
+    assert [bar["time"] for bar in fetched_after["candles"]] == [
         1_700_000_000,
         1_700_000_060,
         1_700_000_120,
     ]
-    assert merged["lastUpdateMs"] == 1_700_000_180_000
+    assert fetched_after["lastUpdateMs"] == 1_700_000_180_000
+
+
+def test_shared_candles_idempotent_updates(client: TestClient) -> None:
+    base_payload = {
+        "symbol": "ETHUSDT",
+        "interval": "5m",
+        "candles": [
+            {"time": 1_700_000_000, "open": 100.0, "high": 110.0, "low": 95.0, "close": 105.0},
+        ],
+        "lastUpdateMs": 1_700_000_060_000,
+        "intervalMs": 300_000,
+        "reset": True,
+    }
+    first = _merge(client, base_payload)
+    assert first["status"] == "ok"
+
+    duplicate = _merge(client, base_payload)
+    assert duplicate["status"] == "noop"
+    assert duplicate["written"] is False
+    assert duplicate["lastUpdateMs"] == 1_700_000_060_000
+
+
+def test_shared_candles_rate_limit(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    monkeypatch.setattr(shared_candles_store, "_WRITE_RATE_LIMIT_SECONDS", 10.0)
+
+    first = _merge(
+        client,
+        {
+            "symbol": "XRPUSDT",
+            "interval": "1m",
+            "candles": [
+                {"time": 1_700_001_000, "open": 0.5, "high": 0.6, "low": 0.4, "close": 0.55},
+            ],
+            "lastUpdateMs": 1_700_001_000_000,
+            "intervalMs": 60_000,
+            "reset": True,
+        },
+    )
+    assert first["status"] == "ok"
+
+    throttled = _merge(
+        client,
+        {
+            "symbol": "XRPUSDT",
+            "interval": "1m",
+            "candles": [
+                {"time": 1_700_001_060, "open": 0.55, "high": 0.7, "low": 0.5, "close": 0.65},
+            ],
+            "lastUpdateMs": 1_700_001_060_000,
+            "intervalMs": 60_000,
+        },
+    )
+    assert throttled["status"] == "rate_limited"
+    assert throttled["written"] is False
+    assert "retryAfterMs" in throttled
 
 
 def test_shared_candles_requires_valid_arguments(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- replace the shared-candles client queue with keyed batching, leader locking, and debounced flushing to keep requests to one per key
- harden the /shared-candles backend with idempotent responses, optional rate limiting, and trimmed persistence backed by tests
- update the chart UI to rely on the shared batching service and ensure inspection snapshots flush the latest shared bars
- make the summary collector tolerant of patched request helpers that do not accept trace parameters

## Testing
- pytest tests/test_shared_candles_api.py tests/test_summary_collector.py

------
https://chatgpt.com/codex/tasks/task_e_68e0fe216f588324bd0f966aa9042c75